### PR TITLE
Automate dependabot merges for patch + minor version changes if they pass CI

### DIFF
--- a/.github/workflows/automate_dependabot.yml
+++ b/.github/workflows/automate_dependabot.yml
@@ -1,0 +1,25 @@
+on: pull_request_target
+
+jobs:
+  approve-dependabot-pr:
+    runs-on: self-hosted
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabot metadata
+        id: dependabot-metadata
+        uses: dependabot/fetch-metadata@v1.1.1
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Approve and merge Dependabot PRs for patch versions
+        if: |
+          steps.dependabot-metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.dependabot-metadata.outputs.update-type == 'version-update:semver-minor'
+        uses: actions/github-script@v5
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '@dependabot merge'
+            })


### PR DESCRIPTION
Chatted to @vinistock IRL

- We agree that we should be doing dependency bumps on VS Code extension repos
- With the amount of projects we've spun up there's a ton of PRs for whoever is on support rotation

So let's automate this a bit.

- Action only runs on pull requests if the user is dependabot
- Will only merge minor and patch versions
- the `@dependabot merge` command does a CI check and will refuse to merge if the checks don't pass so should be safe enough.

Thoughts?