### PR TITLE
Enable dependabot automerge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,9 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: weekly
+      day: tuesday
+      time: "10:00"
+      timezone: America/New_York
     reviewers:
       - "Shopify/sorbet"

--- a/.github/workflows/automate_dependabot.yml
+++ b/.github/workflows/automate_dependabot.yml
@@ -1,25 +1,65 @@
+name: Dependabot auto-merge
 on: pull_request_target
 
+permissions:
+  pull-requests: write
+  contents: write
+
 jobs:
-  approve-dependabot-pr:
+  dependabot:
     runs-on: self-hosted
     if: ${{ github.actor == 'dependabot[bot]' }}
     steps:
       - name: Dependabot metadata
-        id: dependabot-metadata
+        id: metadata
         uses: dependabot/fetch-metadata@v1.1.1
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-      - name: Approve and merge Dependabot PRs for patch versions
-        if: |
-          steps.dependabot-metadata.outputs.update-type == 'version-update:semver-patch' ||
-          steps.dependabot-metadata.outputs.update-type == 'version-update:semver-minor'
+      - name: Enable auto-merge for Dependabot PRs
+        if: ${{ steps.metadata.outputs.update-type != 'version-update:semver-major' }}
         uses: actions/github-script@v5
         with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
           script: |
-            await github.rest.issues.createComment({
-              issue_number: context.issue.number,
+            const getPullRequestIdQuery = `query GetPullRequestId($owner: String!, $repo: String!, $pullRequestNumber: Int!) {
+              repository(owner: $owner, name: $repo) {
+                pullRequest(number: $pullRequestNumber) {
+                  id
+                }
+              }
+            }`
+            const repoInfo = {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: '@dependabot merge'
+              pullRequestNumber: context.issue.number,
+            }
+            const response = await github.graphql(getPullRequestIdQuery, repoInfo)
+
+            await github.rest.pulls.createReview({
+              pull_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              event: 'APPROVE',
             })
+
+            const enableAutoMergeQuery = `mutation ($pullRequestId: ID!, $mergeMethod: PullRequestMergeMethod!) {
+              enablePullRequestAutoMerge(input: {
+                pullRequestId: $pullRequestId,
+                mergeMethod: $mergeMethod
+              }) {
+                pullRequest {
+                  autoMergeRequest {
+                    enabledAt
+                    enabledBy {
+                      login
+                    }
+                  }
+                }
+              }
+            }`
+            const data = {
+              pullRequestId: response.repository.pullRequest.id,
+              mergeMethod: 'MERGE',
+            }
+
+            await github.graphql(enableAutoMergeQuery, data)


### PR DESCRIPTION
Other approach was missing an approval step.
Set up as per [our documentation](https://vault.shopify.io/pages/15549-Dependabot-Automerge) on dependabot automation.

TL;DR:
- Will only run if user is dependabot
- Will only merge if the tests pass
- Human intervention only needed on major versions, merge conflicts, or if the tests fail.