### PR TITLE
Ignore types/vscode

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,5 @@ updates:
       timezone: America/New_York
     reviewers:
       - "Shopify/sorbet"
+    ignore:
+      - dependency-name: "@types/vscode"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "license": "MIT",
   "engines": {
-    "vscode": "^1.65.0"
+    "vscode": "^1.63.0"
   },
   "categories": [
     "Programming Languages"
@@ -39,7 +39,7 @@
     "@types/glob": "^7.2.0",
     "@types/mocha": "^9.1.0",
     "@types/node": "17.x",
-    "@types/vscode": "^1.65.0",
+    "@types/vscode": "^1.63.0",
     "@typescript-eslint/eslint-plugin": "^5.15.0",
     "@typescript-eslint/parser": "^5.15.0",
     "@vscode/test-electron": "^2.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -563,9 +563,9 @@
   resolved "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
-"@types/vscode@^1.65.0":
+"@types/vscode@^1.63.0":
   version "1.65.0"
-  resolved "https://registry.npmjs.org/@types/vscode/-/vscode-1.65.0.tgz"
+  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.65.0.tgz#042dd8d93c32ac62cb826cd0fa12376069d1f448"
   integrity sha512-wQhExnh2nEzpjDMSKhUvnNmz3ucpd3E+R7wJkOhBNK3No6fG3VUdmVmMOKD0A8NDZDDDiQcLNxe3oGmX5SjJ5w==
 
 "@types/websocket@1.0.2":


### PR DESCRIPTION
Automatically bumping `@types/vscode` forces us to bump the engine as well, which drops support for older versions of vscode quicker than we would like.

It'd be good to support at least 2 versions back. I suggest we ignore this dependency and bump it manually, so that we can support older versions of vscode.