### PR TITLE
Add start, restart and stop commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,22 @@
     "workspaceContains:Gemfile.lock"
   ],
   "main": "./out/extension.js",
-  "contributes": {},
+  "contributes": {
+    "commands": [
+      {
+        "command": "ruby-lsp.start",
+        "title": "Ruby LSP: Start"
+      },
+      {
+        "command": "ruby-lsp.restart",
+        "title": "Ruby LSP: Restart"
+      },
+      {
+        "command": "ruby-lsp.stop",
+        "title": "Ruby LSP: Stop"
+      }
+    ]
+  },
   "scripts": {
     "vscode:prepublish": "yarn run esbuild-base --minify",
     "package": "vsce package --out vscode-ruby-lsp.vsix",


### PR DESCRIPTION
Add commands to start, restart and stop the LSP. These are convenient not only for development, but for users.

### Tophat

1. Make sure `ruby-lsp` is using the latest main
2. Start debugging F5
3. cmd + shift + p to open the command pallet
4. Select stop, start or restart and watch the output produced by the LSP