### PR TITLE
Add automatic LSP restarts

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -44,6 +44,7 @@ export default class Client {
 
     this.context = context;
     this.registerCommands();
+    this.registerAutoRestarts();
   }
 
   async start() {
@@ -129,5 +130,24 @@ export default class Client {
     });
 
     return result.stdout;
+  }
+
+  private registerAutoRestarts() {
+    if (this.context.extensionMode === vscode.ExtensionMode.Development) {
+      this.createRestartWatcher("**/*.rb");
+    }
+
+    this.createRestartWatcher("Gemfile.lock");
+  }
+
+  private createRestartWatcher(pattern: string) {
+    const watcher = vscode.workspace.createFileSystemWatcher(
+      new vscode.RelativePattern(this.workingFolder, pattern)
+    );
+    this.context.subscriptions.push(watcher);
+
+    watcher.onDidChange(() => this.restart());
+    watcher.onDidCreate(() => this.restart());
+    watcher.onDidDelete(() => this.restart());
   }
 }


### PR DESCRIPTION
Make the LSP automatically restart if
- There's a Gemfile.lock change
- We're running in development mode and any Ruby file was changed. This is incredibly useful when developing `ruby-lsp`, because simply saving the file will make you see the behaviour changes immediately, without having to restart the debugging process in VS Code.