### PR TITLE
Fix publish script

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,17 +10,19 @@ jobs:
       - uses: actions/checkout@v2
         name: Checkout
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v3
         name: Use Node.js 17.x
         with:
           node-version: "17"
-          cache: "yarn"
+
+      - name: Setup yarn
+        run: npm install -g yarn
 
       - name: 📦 Install dependencies
         run: yarn --frozen-lockfile
 
       - name: 🔨 Package
-        run: yarn vsce package
+        run: yarn run package
 
       - name: Upload assets to release
         uses: Shopify/upload-to-release@master


### PR DESCRIPTION
Fix the publish script according to our recent learnings. When we open source the repo, we'll need to adapt this to also publish to the marketplace, but for the time being we can create alpha release to test them out with the VSIX.