### PR TITLE
Never reveal the output channel

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -7,6 +7,7 @@ import {
   LanguageClient,
   ServerOptions,
   Executable,
+  RevealOutputChannelOn,
 } from "vscode-languageclient/node";
 
 const asyncExec = promisify(exec);
@@ -40,6 +41,7 @@ export default class Client {
       documentSelector: [{ scheme: "file", language: "ruby" }],
       diagnosticCollectionName: LSP_NAME,
       outputChannel,
+      revealOutputChannelOn: RevealOutputChannelOn.Never,
     };
 
     this.context = context;


### PR DESCRIPTION
When an error occurs in the LSP, the default is for VS Code to auto-focus on the output channel tab, which can be very annoying. Set `revealOutputChannelOn` to never, so that we never auto-focus on it.