### PR TITLE
Do not re-prompt when cancelling bundle add

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -84,6 +84,10 @@ export default class Client {
   }
 
   private async gemMissing(): Promise<boolean> {
+    if (this.context.workspaceState.get("ruby-lsp.cancelledBundleAdd")) {
+      return true;
+    }
+
     const bundledGems = await this.execInPath("bundle list");
 
     if (bundledGems.includes("ruby-lsp")) {
@@ -102,6 +106,7 @@ export default class Client {
       return false;
     }
 
+    this.context.workspaceState.update("ruby-lsp.cancelledBundleAdd", true);
     return true;
   }
 


### PR DESCRIPTION
Right now, every time you open a Ruby workspace that doesn't include `ruby-lsp` as a part of the bundle, we prompt the user to `bundle add` and `bundle install` - even when selecting cancel.

This may be a bit much and might bother users, so this PR just saves in the workspace state if the `bundle add` operation has been cancelled and avoids prompting again if so.


### Tophat

1. Start the extension on this branch (F5)
2. On the extension debug window, switch to any project that doesn't have `ruby-lsp`
3. Verify you get prompted to run `bundle add`
4. Click `Cancel`
5. Switch to a different project (any) and then switch back again to the same project where you clicked `Cancel`
6. Verify you don't get prompted a second time to add `ruby-lsp`