### PR TITLE
Remove development auto-restart

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -153,10 +153,6 @@ export default class Client {
   }
 
   private registerAutoRestarts() {
-    if (this.context.extensionMode === vscode.ExtensionMode.Development) {
-      this.createRestartWatcher("**/*.rb");
-    }
-
     this.createRestartWatcher("Gemfile.lock");
 
     // If a configuration that affects the Ruby LSP has changed, update the client options using the latest


### PR DESCRIPTION
The auto restart for development mode is causing issues with quick actions. We save the file and then, while the LSP is restarting, it tries to send code actions at the same time to a closed stream, which causes the process to crash.

This ends up being a much worse development experience than having to reload the process in the VS Code window.