### PR TITLE
Avoid running multiple release jobs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,8 @@
 name: Release
 
-on: [release]
+on:
+  release:
+    types: [created]
 
 jobs:
   release:
@@ -29,4 +31,4 @@ jobs:
         with:
           name: vscode-ruby-lsp.vsix
           path: vscode-ruby-lsp.vsix
-          repo-token: ${{secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Similar to what we did in https://github.com/Shopify/vscode-shopify-ruby/pull/66, avoid running 3 jobs on every release and instead run a single one.