### PR TITLE
Move cancelled check lower in the hierarchy

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -97,14 +97,14 @@ export default class Client {
   }
 
   private async gemMissing(): Promise<boolean> {
-    if (this.context.workspaceState.get("ruby-lsp.cancelledBundleAdd")) {
-      return true;
-    }
-
     const bundledGems = await this.execInPath("bundle list");
 
     if (bundledGems.includes("ruby-lsp")) {
       return false;
+    }
+
+    if (this.context.workspaceState.get("ruby-lsp.cancelledBundleAdd")) {
+      return true;
     }
 
     const response = await vscode.window.showErrorMessage(


### PR DESCRIPTION
While testing the LSP, I noticed that it never started. The reason was because I had clicked `Cancel` and we were exiting early before even checking if the gem was present.

However, if someone cancelled adding the gem to the bundle, but the gem is now a part of it, we should just start the LSP and not check if bundle add was cancelled.


### Manual tests

1. Start the plugin and open a project that does not have the `ruby-lsp` (e.g.: Core)
2. Verify you get prompted to add `ruby-lsp` to the bundle
3. Click cancel
4. Manually add `ruby-lsp` to the `Gemfile` and bundle install
5. Reload the LSP and make sure that it starts