### PR TITLE
Run bundle add with group=development

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -123,7 +123,7 @@ export default class Client {
     );
 
     if (response === "Run bundle add and install") {
-      await this.execInPath("bundle add ruby-lsp");
+      await this.execInPath("bundle add ruby-lsp --group=development");
       await this.execInPath("bundle install");
       return false;
     }


### PR DESCRIPTION
A tiny improvement: when prompting for adding the `ruby-lsp` to the bundle, we weren't using `group=development` as an option.

We don't want the gem to be added to all groups, so we better scope it to development.