### PR TITLE
Change `vscode-ruby-lsp` to `ruby-lsp` in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ VS Code extension for the [Ruby LSP gem](https://github.com/Shopify/ruby-lsp).
 
 ## Usage
 
-Search for `vscode-ruby-lsp` in the extensions tab and click install.
+Search for `ruby-lsp` in the extensions tab and click install.
 
 ### Telemetry
 


### PR DESCRIPTION
Since the extension name is `ruby-lsp`, searching for `vscode-ruby-lsp` does not return anything.