### PR TITLE
Prompt users to remove rubocop-lsp if present

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -68,7 +68,7 @@ export default class Client {
   }
 
   async start() {
-    if ((await this.gemMissing()) || (await this.gemNotInstalled())) {
+    if ((await this.gemNotInstalled()) || (await this.gemMissing())) {
       return;
     }
 
@@ -107,6 +107,19 @@ export default class Client {
 
   private async gemMissing(): Promise<boolean> {
     const bundledGems = await this.execInPath("bundle list");
+
+    if (bundledGems.includes("rubocop-lsp")) {
+      vscode.window.showErrorMessage(
+        "The rubocop-lsp gem has been replaced by the ruby-lsp.",
+        {
+          modal: true,
+          detail:
+            "Please, remove the rubocop-lsp and add ruby-lsp to your Gemfile",
+        }
+      );
+
+      return true;
+    }
 
     if (bundledGems.includes("ruby-lsp")) {
       return false;

--- a/src/client.ts
+++ b/src/client.ts
@@ -107,21 +107,20 @@ export default class Client {
 
   private async gemMissing(): Promise<boolean> {
     const bundledGems = await this.execInPath("bundle list");
+    const hasRubocopLsp = bundledGems.includes("rubocop-lsp");
+    const hasRubyLsp = bundledGems.includes("ruby-lsp");
 
-    if (bundledGems.includes("rubocop-lsp")) {
-      vscode.window.showErrorMessage(
+    if (hasRubocopLsp) {
+      await vscode.window.showErrorMessage(
         "The rubocop-lsp gem has been replaced by the ruby-lsp.",
         {
           modal: true,
-          detail:
-            "Please, remove the rubocop-lsp and add ruby-lsp to your Gemfile",
+          detail: "Please remove the rubocop-lsp from the Gemfile",
         }
       );
-
-      return true;
     }
 
-    if (bundledGems.includes("ruby-lsp")) {
+    if (hasRubyLsp) {
       return false;
     }
 


### PR DESCRIPTION
Now that the `ruby-lsp` supports all features from the `rubocop-lsp`, we can help users cleanup their apps by prompting them to remove the gem.

This PR does two things
1. Inverts the order of the gem checks. Bundle list actually fails if gems aren't installed, so we should do `bundle check` first
2. Adds a prompt if `rubocop-lsp` is a part of the bundle

### Manual tests

1. Start the plugin on this branch
2. On the opened window, select a project that has the `rubocop-lsp` installed
3. Verify you get prompted