### PR TITLE
Bump version to 0.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [0.0.2]
+
+- Prompt users to remove rubocop-lsp gem if installed (https://github.com/Shopify/vscode-ruby-lsp/pull/79)
+- Run bundle add with group=development (https://github.com/Shopify/vscode-ruby-lsp/pull/77)
+- Add the ability to connect to a private telemetry extension (https://github.com/Shopify/vscode-ruby-lsp/pull/60)
+
 ## [0.0.1]
 
 - Initial release

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ruby-lsp",
   "displayName": "ruby-lsp",
   "description": "VS Code plugin for connecting with the Ruby LSP",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "publisher": "Shopify",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Bump version to 0.0.2.

By releasing the new `rubocop-lsp` check, we unblock releasing a new version of the extension pack, including the Ruby LSP and removing `rubocop-lsp`.