### PR TITLE
Add selection ranges to the extension configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,11 @@
               "type": "boolean",
               "default": true
             },
+            "selectionRanges": {
+              "description": "Enable selection ranges, which selects code based on the position of the cursor(s)",
+              "type": "boolean",
+              "default": true
+            },
             "semanticHighlighting": {
               "description": "Enable semantic highlighting, which highlights code based on Ruby's understanding of it",
               "type": "boolean",
@@ -76,6 +81,7 @@
           "default": {
             "documentSymbols": true,
             "foldingRanges": true,
+            "selectionRanges": true,
             "semanticHighlighting": true,
             "formatting": true,
             "diagnostics": true,

--- a/src/client.ts
+++ b/src/client.ts
@@ -19,6 +19,7 @@ interface EnabledFeatures {
   [key: string]: boolean;
   documentSymbols: boolean;
   foldingRanges: boolean;
+  selectionRanges: boolean;
   semanticHighlighting: boolean;
   formatting: boolean;
   diagnostics: boolean;


### PR DESCRIPTION
This PR adds configuration for selection ranges to the VS Code extension. It is a companion PR to [Shopify/ruby-lsp#88](https://github.com/Shopify/ruby-lsp/pull/88), which added the selection ranges to the ruby-lsp repo.

I don't think I need to add tests or anything, but let me know if there's something missing.