### PR TITLE
Remove plugin order dependency from telemetry

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -59,7 +59,6 @@ export default class Client {
       revealOutputChannelOn: RevealOutputChannelOn.Never,
       initializationOptions: {
         enabledFeatures: this.listOfEnabledFeatures(),
-        telemetryEnabled: telemetry.enabled(),
       },
     };
 
@@ -79,10 +78,7 @@ export default class Client {
       this.clientOptions
     );
 
-    if (this.telemetry.enabled()) {
-      this.client.onTelemetry(this.telemetry.sendEvent.bind(this.telemetry));
-    }
-
+    this.client.onTelemetry(this.telemetry.sendEvent.bind(this.telemetry));
     this.context.subscriptions.push(this.client.start());
     await this.client.onReady();
   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,8 +9,6 @@ export async function activate(context: vscode.ExtensionContext) {
   activateRuby();
 
   const telemetry = new Telemetry(context);
-  await telemetry.initialize();
-
   client = new Client(context, telemetry);
 
   // Adding this delay guarantees that shadowenv has enough time to load the right environment

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -22,7 +22,6 @@ class DevelopmentApi implements TelemetryApi {
 
 export class Telemetry {
   private api?: TelemetryApi;
-  private initializationAttempts = 0;
 
   constructor(context: vscode.ExtensionContext, api?: TelemetryApi) {
     if (context.extensionMode === vscode.ExtensionMode.Development && !api) {
@@ -39,16 +38,11 @@ export class Telemetry {
   }
 
   private async initialize(): Promise<boolean> {
-    if (this.initializationAttempts > 5) {
-      return false;
-    }
-
     try {
       if (!this.api) {
         this.api = await vscode.commands.executeCommand(
           "ruby-lsp.getPrivateTelemetryApi"
         );
-        this.initializationAttempts++;
       }
 
       return Boolean(this.api);

--- a/src/test/suite/telemetry.test.ts
+++ b/src/test/suite/telemetry.test.ts
@@ -56,7 +56,6 @@ suite("Telemetry", () => {
       errorMessage: "undefined method `visit` for nil:NilClass",
     };
 
-    await telemetry.initialize();
     await telemetry.sendEvent(event);
     assert.strictEqual(api.sentEvents[0], event);
   });


### PR DESCRIPTION
### Motivation

Originally, we were trying to load the private telemetry API when activating the extension and then, if the command was present, telling the server that telemetry was enabled.

However, this approach is brittle because it makes the telemetry depend on the load order of the plugins. If a private metrics plugin is loaded after the Ruby LSP plugin, then the command will not have been registered yet and we fail to inform the server that there is a telemetry API.

### Implementation

I believe the most robust option is to have the server always push `telemetry/event` notifications (removing the concept of enabling the server telemetry).

Then here, on the plugin side, we try to initialize the metrics API object via the command when trying to send metrics. If we're unable to get an API object after 5 attempts, then it probably means there is no private metrics plugin and we can stop re-trying.

