### PR TITLE
Add error telemetry fields

### DIFF
--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -5,6 +5,8 @@ export interface TelemetryEvent {
   requestTime: number;
   lspVersion: string;
   uri?: string;
+  errorClass?: string;
+  errorMessage?: string;
 }
 
 export interface TelemetryApi {

--- a/src/test/suite/telemetry.test.ts
+++ b/src/test/suite/telemetry.test.ts
@@ -30,6 +30,8 @@ suite("Telemetry", () => {
       requestTime: 0.005,
       lspVersion: "1.0.0",
       uri: "file:///test.rb",
+      errorClass: "NoMethodError",
+      errorMessage: "undefined method `visit` for nil:NilClass",
     };
 
     await telemetry.sendEvent(event);
@@ -50,6 +52,8 @@ suite("Telemetry", () => {
       requestTime: 0.005,
       lspVersion: "1.0.0",
       uri: "file:///test.rb",
+      errorClass: "NoMethodError",
+      errorMessage: "undefined method `visit` for nil:NilClass",
     };
 
     await telemetry.initialize();


### PR DESCRIPTION
Add the error telemetry fields from https://github.com/Shopify/ruby-lsp/pull/100 in our `TelemetryEvent` type.