### PR TITLE
Bump version to 0.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Check [Keep a Changelog](http://keepachangelog.com/) for recommendations on how 
 
 ## [Unreleased]
 
+## [0.0.3]
+
+- Add new error telemetry fields (https://github.com/Shopify/vscode-ruby-lsp/pull/107)
+- Enable document highlight by default (https://github.com/Shopify/vscode-ruby-lsp/pull/76)
+- Remove plugin load order dependency for telemetry (https://github.com/Shopify/vscode-ruby-lsp/pull/85)
+
 ## [0.0.2]
 
 - Prompt users to remove rubocop-lsp gem if installed (https://github.com/Shopify/vscode-ruby-lsp/pull/79)

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "ruby-lsp",
-  "displayName": "ruby-lsp",
+  "displayName": "Ruby LSP",
   "description": "VS Code plugin for connecting with the Ruby LSP",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "publisher": "Shopify",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Bump version to 0.0.3 to release the telemetry fixes and to enable document highlight by default.

I also took the opportunity to replace our display name from `ruby-lsp` to `Ruby LSP`, which looks nicer in the extensions tab.