### PR TITLE
Add snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,11 @@ VS Code extension for the [Ruby LSP gem](https://github.com/Shopify/ruby-lsp).
 
 Search for `ruby-lsp` in the extensions tab and click install.
 
+### Snippets
+
+The Ruby LSP provides convenience snippets for Ruby. Find the full list
+[here](https://github.com/Shopify/vscode-ruby-lsp/blob/main/snippets.json).
+
 ### Telemetry
 
 On its own, the Ruby LSP does not collect any telemetry by default, but it does support hooking up to a private metrics
@@ -47,10 +52,6 @@ vscode.commands.registerCommand(
 );
 ```
 
-### Debugging
-
-Interactive debugging works for both running the extension or tests. In the debug panel, select whether to run the extension in development mode or run tests, set up some breakpoints and start with F5.
-
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/Shopify/vscode-ruby-lsp.
@@ -58,6 +59,10 @@ This project is intended to be a safe, welcoming space for collaboration, and co
 are expected to adhere to the
 [Contributor Covenant](https://github.com/Shopify/vscode-ruby-lsp/blob/main/CODE_OF_CONDUCT.md)
 code of conduct.
+
+### Debugging
+
+Interactive debugging works for both running the extension or tests. In the debug panel, select whether to run the extension in development mode or run tests, set up some breakpoints and start with F5.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "vscode": "^1.63.0"
   },
   "categories": [
-    "Programming Languages"
+    "Programming Languages",
+    "Snippets"
   ],
   "activationEvents": [
     "onLanguage:ruby",
@@ -96,7 +97,13 @@
           }
         }
       }
-    }
+    },
+    "snippets": [
+      {
+        "language": "ruby",
+        "path": "./snippets.json"
+      }
+    ]
   },
   "scripts": {
     "vscode:prepublish": "yarn run esbuild-base --minify",

--- a/snippets.json
+++ b/snippets.json
@@ -76,5 +76,70 @@
     "prefix": ["begin"],
     "body": ["begin", "  $0", "rescue $1", "ensure", "end", ""],
     "description": "New Ruby begin block with rescue and ensure."
+  },
+  "While": {
+    "prefix": ["while"],
+    "body": ["while $1", "  $0", "end", ""],
+    "description": "New Ruby while loop."
+  },
+  "Until": {
+    "prefix": ["until"],
+    "body": ["until $1", "  $0", "end", ""],
+    "description": "New Ruby until loop."
+  },
+  "For": {
+    "prefix": ["for"],
+    "body": ["for $1 in $2", "  $0", "end", ""],
+    "description": "New Ruby for loop."
+  },
+  "Each inline": {
+    "prefix": ["each"],
+    "body": ["each { |$1| $0 }"],
+    "description": "New Ruby inline each loop."
+  },
+  "Each block": {
+    "prefix": ["each"],
+    "body": ["each do |$1|", "  $0", "end"],
+    "description": "New Ruby each loop."
+  },
+  "Map inline": {
+    "prefix": ["map"],
+    "body": ["map { |$1| $0 }"],
+    "description": "New Ruby inline map loop."
+  },
+  "Map block": {
+    "prefix": ["map"],
+    "body": ["map do |$1|", "  $0", "end"],
+    "description": "New Ruby map loop."
+  },
+  "Flat map inline": {
+    "prefix": ["flat_map"],
+    "body": ["flat_map { |$1| $0 }"],
+    "description": "New Ruby inline flat_map loop."
+  },
+  "Flat Map block": {
+    "prefix": ["flat_map"],
+    "body": ["flat_map do |$1|", "  $0", "end"],
+    "description": "New Ruby flat_map loop."
+  },
+  "Select inline": {
+    "prefix": ["select"],
+    "body": ["select { |$1| $0 }"],
+    "description": "New Ruby inline select loop."
+  },
+  "Select block": {
+    "prefix": ["select"],
+    "body": ["select do |$1|", "  $0", "end"],
+    "description": "New Ruby select loop."
+  },
+  "Find inline": {
+    "prefix": ["find"],
+    "body": ["find { |$1| $0 }"],
+    "description": "New Ruby inline find loop."
+  },
+  "Find block": {
+    "prefix": ["find"],
+    "body": ["find do |$1|", "  $0", "end"],
+    "description": "New Ruby find loop."
   }
 }

--- a/snippets.json
+++ b/snippets.json
@@ -61,5 +61,20 @@
     "prefix": ["module"],
     "body": ["module $1", "  def $2", "    $0", "  end", "end", ""],
     "description": "New Ruby module."
+  },
+  "Begin block": {
+    "prefix": ["begin"],
+    "body": ["begin", "  $0", "end", ""],
+    "description": "New Ruby begin block."
+  },
+  "Begin rescue block": {
+    "prefix": ["begin"],
+    "body": ["begin", "  $0", "rescue $1", "end", ""],
+    "description": "New Ruby begin block with rescue."
+  },
+  "Begin rescue ensure": {
+    "prefix": ["begin"],
+    "body": ["begin", "  $0", "rescue $1", "ensure", "end", ""],
+    "description": "New Ruby begin block with rescue and ensure."
   }
 }

--- a/snippets.json
+++ b/snippets.json
@@ -1,0 +1,55 @@
+{
+  "New Minitest spec": {
+    "prefix": ["Minitest"],
+    "body": [
+      "# frozen_string_literal: true",
+      "",
+      "require \"spec_helper\"",
+      "",
+      "class $1 < Minitest::Spec",
+      "  describe \"$2\" do",
+      "    it \"$3\" do",
+      "      $0",
+      "      assert(true)",
+      "    end",
+      "  end",
+      "end",
+      ""
+    ],
+    "description": "New Minitest class using the spec syntax."
+  },
+  "New Minitest test": {
+    "prefix": ["Minitest"],
+    "body": [
+      "# frozen_string_literal: true",
+      "",
+      "require \"test_helper\"",
+      "",
+      "class $1 < Minitest::Test",
+      "  def test_$2",
+      "    $0",
+      "    assert(true)",
+      "  end",
+      "end",
+      ""
+    ],
+    "description": "New Minitest class using the test syntax."
+  },
+  "New Rspec test": {
+    "prefix": ["Rspec"],
+    "body": [
+      "# frozen_string_literal: true",
+      "",
+      "describe $1 do",
+      "  describe \"$2\" do",
+      "    it \"$3\" do",
+      "      $0",
+      "      expect(true).to eq(true)",
+      "    end",
+      "  end",
+      "end",
+      ""
+    ],
+    "description": "New Minitest class using the spec syntax."
+  }
+}

--- a/snippets.json
+++ b/snippets.json
@@ -166,5 +166,25 @@
     "prefix": ["attr"],
     "body": ["attr_writer :$1"],
     "description": "New attribute writer."
+  },
+  "If": {
+    "prefix": ["if"],
+    "body": ["if $1", "  $0", "end"],
+    "description": "New if statement."
+  },
+  "If else": {
+    "prefix": ["if"],
+    "body": ["if $1", "  $0", "else", "end"],
+    "description": "New if statement with else."
+  },
+  "If elsif": {
+    "prefix": ["if"],
+    "body": ["if $1", "  $0", "elsif $2", "  $0", "end"],
+    "description": "New if statement with elsif."
+  },
+  "Unless": {
+    "prefix": ["unless"],
+    "body": ["unless $1", "  $0", "end"],
+    "description": "New unless statement."
   }
 }

--- a/snippets.json
+++ b/snippets.json
@@ -51,5 +51,15 @@
       ""
     ],
     "description": "New Minitest class using the spec syntax."
+  },
+  "New class": {
+    "prefix": ["class"],
+    "body": ["class $1", "  def initialize", "    $0", "  end", "end", ""],
+    "description": "New Ruby class."
+  },
+  "New module": {
+    "prefix": ["module"],
+    "body": ["module $1", "  def $2", "    $0", "  end", "end", ""],
+    "description": "New Ruby module."
   }
 }

--- a/snippets.json
+++ b/snippets.json
@@ -141,5 +141,30 @@
     "prefix": ["find"],
     "body": ["find do |$1|", "  $0", "end"],
     "description": "New Ruby find loop."
+  },
+  "Define method": {
+    "prefix": ["def"],
+    "body": ["def $1", "  $0", "end"],
+    "description": "New method."
+  },
+  "Define singleton method": {
+    "prefix": ["def"],
+    "body": ["def self.$1", "  $0", "end"],
+    "description": "New singleton method."
+  },
+  "Define attribute accessor": {
+    "prefix": ["attr"],
+    "body": ["attr_accessor :$1"],
+    "description": "New attribute accessor."
+  },
+  "Define attribute reader": {
+    "prefix": ["attr"],
+    "body": ["attr_reader :$1"],
+    "description": "New attribute reader."
+  },
+  "Define attribute writer": {
+    "prefix": ["attr"],
+    "body": ["attr_writer :$1"],
+    "description": "New attribute writer."
   }
 }


### PR DESCRIPTION
We received some feedback mentioning that we didn't include snippets for common Ruby code. I think it's fair to add some, since they are low effort ways of getting some kind of completion.

This PR adds snippets to the extension. I tried to include basic Ruby keywords like loops, conditionals, classes, modules and methods, but also added three snippets to create new test files.

If you have ideas on more snippets, especially things that typically require looking up documentation, let me know so that I can add some more.

### Manual tests

1. Start the extension on this branch
2. Open any Ruby file
3. Start typing the snippet's prefix
4. Select the desired snippet
5. Pressing tab moves through the anchor points. The anchors work in order (`$1` is the first, `$2` is the second...), with the exception of `$0` which is the position where the cursor should end up once the snippet is complete