### PR TITLE
Catch bundler check error

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -141,7 +141,13 @@ export default class Client {
   }
 
   private async gemNotInstalled(): Promise<boolean> {
-    const bundlerCheck = await this.execInPath("bundle check");
+    let bundlerCheck: string;
+
+    try {
+      bundlerCheck = await this.execInPath("bundle check");
+    } catch {
+      bundlerCheck = "";
+    }
 
     if (bundlerCheck.includes("The Gemfile's dependencies are satisfied")) {
       return false;


### PR DESCRIPTION
If `bundler check` fails, it actually throws an error that we weren't catching, which made us not display the prompt to bundle install.

Catching the error is enough to make it work.

### Manual tests

1. Start the LSP using this branch
2. In the project that uses `ruby-lsp`, uninstall some gems so that `bundler check` doesn't pass (e.g.: `gem uninstall syntax_tree`)
3. Reload the window
4. Verify you get prompted to bundle install
5. Verify clicking bundle install makes the LSP start normally