### PR TITLE
Auto-restart the LSP on .rubocop.yml config changes

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -177,7 +177,7 @@ export default class Client {
 
   private registerAutoRestarts() {
     this.createRestartWatcher("Gemfile.lock");
-    this.createRestartWatcher(".rubocop.yml");
+    this.createRestartWatcher("**/.rubocop.yml");
 
     // If a configuration that affects the Ruby LSP has changed, update the client options using the latest
     // configuration and restart the server


### PR DESCRIPTION
If the RuboCop configuration changes, then we have to restart the LSP to reload the diagnostics and formatting runners. Otherwise, we keep processing files using the old configuration.