### PR TITLE
Add on type formatting with snippet support

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,11 @@
               "type": "boolean",
               "default": true
             },
+            "onTypeFormatting": {
+              "description": "Enable on type formatting",
+              "type": "boolean",
+              "default": true
+            },
             "diagnostics": {
               "description": "Enable diagnostics, like RuboCop violations",
               "type": "boolean",
@@ -99,7 +104,8 @@
             "semanticHighlighting": true,
             "formatting": true,
             "diagnostics": true,
-            "codeActions": true
+            "codeActions": true,
+            "onTypeFormatting": true
           }
         }
       }


### PR DESCRIPTION
When investigating some other aspects of the specification, I stumbled upon `onTypeFormatting` and couldn't stop myself from implementing this for automatically closing Ruby tokens - which is something I miss a lot using VS Code.

### What is on type formatting

We register specific characters that we want VS Code to send `onTypeFormatting` requests for on the server side. When we receive the requests, we can send back text edits to automatically format the code around that edit.

One common way of using this is adding `end ` tokens automatically when adding a line break, automatically closing pipes for block arguments or closing braces for string interpolation.

### VS Code extension changes

Theoretically, we wouldn't need any changes other than the ones in `package.json` and everything would be implemented in the server. However, VS Code currently [does not support specifying the final cursor position](https://github.com/microsoft/language-server-protocol/issues/724) for a text edit.

For example, if we add an `end` automatically when typing `if`, the cursor would not be placed between the `if` and the `end`, but would always be at the last character of `end`. This is not an optimal experience, as we'd like to place be able to decide where the cursor should end up.

To get around that, this PR adds a middleware for `onTypeFormatting` to process `$0` snippet anchors that come from text edits. This anchor makes VS Code move the cursor to the desired position, which results in the experience we'd like to provide.

The logic is:
- If there is no `$0` in the `onTypeFormatting` response, just return the response and let VS Code handle it
- If there is an `$0` anchor, then apply the edits regular edits first and then apply the `$0` snippet at the end to move the cursor to the desired position

### Manual tests
1. Enable on type formatting in your JSON settings `"editor.formatOnType": true`
2. Start the LSP using this branch for the extension and [this branch for the server](https://github.com/Shopify/ruby-lsp/pull/253)
2. Type `if something` and press return
3. Verify that `end` is added automatically
4. Verify that the cursor is positioning inside of the if block
5. Repeat for other common patterns, like `do`, `unless`, `while`, `class`...