### PR TITLE
Add params and backtrace to error telemetry

### DIFF
--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -7,6 +7,8 @@ export interface TelemetryEvent {
   uri?: string;
   errorClass?: string;
   errorMessage?: string;
+  backtrace?: string;
+  params?: string;
 }
 
 export interface TelemetryApi {

--- a/src/test/suite/telemetry.test.ts
+++ b/src/test/suite/telemetry.test.ts
@@ -32,6 +32,8 @@ suite("Telemetry", () => {
       uri: "file:///test.rb",
       errorClass: "NoMethodError",
       errorMessage: "undefined method `visit` for nil:NilClass",
+      params: '{"position": {"line": 0, "character": 0}}',
+      backtrace: "test.rb:1:in `visit'\ntest.rb:5:in `block in <main>'",
     };
 
     await telemetry.sendEvent(event);


### PR DESCRIPTION
Companion PR for https://github.com/Shopify/ruby-lsp/pull/301.

This just adds the new fields to our telemetry event type.