### PR TITLE
Add support for chruby

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,10 +35,13 @@ In order to boot the server properly, the Ruby version manager must be configure
 Check the [package.json](https://github.com/Shopify/vscode-ruby-lsp/blob/main/package.json) for currently supported
 managers.
 
+To make sure that the Ruby LSP can find the version manager scripts, make sure that they are loaded in the shell's
+configuration script (e.g.: ~/.bashrc, ~/.zshrc) and that the SHELL environment variable is set and pointing to the
+default shell.
+
 ```jsonc
 "rubyLsp.rubyVersionManager": {
   "manager": "chruby", // The handle for the version manager (e.g.: chruby, shadowenv)
-  "path": "/opt/homebrew/opt/chruby/chruby.sh" // The path for the script or executable
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,12 +12,6 @@ Companion VS Code extension for the [Ruby LSP gem](https://github.com/Shopify/ru
 
 Search for `ruby-lsp` in the extensions tab and click install.
 
-**Note**
-
-For this extension to properly start the Ruby LSP server, the right Ruby version for the project being worked on must be
-activated or else it can't find the right gems. Currently, auto activation is only supported for `shadowenv`, but
-support will be added for other Ruby version managers soon.
-
 ### Configuration
 
 The Ruby LSP has all its features enabled by default, but disabling specific features is supported by changing the
@@ -34,6 +28,17 @@ following configuration (definition of all available values can be found in the
   "formatting": true,
   "diagnostics": true,
   "codeActions": true
+}
+```
+
+In order to boot the server properly, the Ruby version manager must be configured, which defaults to using shadowenv.
+Check the [package.json](https://github.com/Shopify/vscode-ruby-lsp/blob/main/package.json) for currently supported
+managers.
+
+```jsonc
+"rubyLsp.rubyVersionManager": {
+  "manager": "chruby", // The handle for the version manager (e.g.: chruby, shadowenv)
+  "path": "/opt/homebrew/opt/chruby/chruby.sh" // The path for the script or executable
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -115,28 +115,13 @@
           }
         },
         "rubyLsp.rubyVersionManager": {
-          "description": "Ruby version manager configuration",
-          "type": "object",
-          "properties": {
-            "manager": {
-              "description": "The Ruby version manager to use",
-              "type": "string",
-              "enum": [
-                "shadowenv",
-                "chruby"
-              ],
-              "default": "shadowenv"
-            },
-            "path": {
-              "description": "The path to the Ruby version manager script or executable",
-              "type": "string",
-              "default": ""
-            }
-          },
-          "default": {
-            "manager": "shadowenv",
-            "path": ""
-          }
+          "description": "The Ruby version manager to use",
+          "type": "string",
+          "enum": [
+            "shadowenv",
+            "chruby"
+          ],
+          "default": "shadowenv"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -113,6 +113,30 @@
             "selectionRanges": true,
             "semanticHighlighting": true
           }
+        },
+        "rubyLsp.rubyVersionManager": {
+          "description": "Ruby version manager configuration",
+          "type": "object",
+          "properties": {
+            "manager": {
+              "description": "The Ruby version manager to use",
+              "type": "string",
+              "enum": [
+                "shadowenv",
+                "chruby"
+              ],
+              "default": "shadowenv"
+            },
+            "path": {
+              "description": "The path to the Ruby version manager script or executable",
+              "type": "string",
+              "default": ""
+            }
+          },
+          "default": {
+            "manager": "shadowenv",
+            "path": ""
+          }
         }
       }
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,16 +2,17 @@ import * as vscode from "vscode";
 
 import Client from "./client";
 import { Telemetry } from "./telemetry";
+import { Ruby } from "./ruby";
 
 let client: Client;
 
 export async function activate(context: vscode.ExtensionContext) {
-  activateRuby();
+  await new Ruby().activateRuby();
 
   const telemetry = new Telemetry(context);
   client = new Client(context, telemetry);
 
-  // Adding this delay guarantees that shadowenv has enough time to load the right environment
+  // Adding this delay guarantees that the Ruby environment is activated before trying to start the server
   await delay(500);
   await client.start();
 }
@@ -20,10 +21,6 @@ async function delay(mseconds: number) {
   return new Promise((resolve) => {
     setTimeout(resolve, mseconds);
   });
-}
-
-function activateRuby() {
-  vscode.extensions.getExtension("shopify.vscode-shadowenv")?.activate();
 }
 
 export async function deactivate(): Promise<void> {

--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -1,0 +1,73 @@
+import { exec } from "child_process";
+import { promisify } from "util";
+import * as fs from "fs";
+
+import * as vscode from "vscode";
+
+const asyncExec = promisify(exec);
+const asyncReadFile = promisify(fs.readFile);
+
+export class Ruby {
+  private workingFolder: string;
+  private managerConfiguration: { [key: string]: string };
+
+  constructor() {
+    this.workingFolder = vscode.workspace.workspaceFolders![0].uri.fsPath;
+
+    this.managerConfiguration = vscode.workspace
+      .getConfiguration("rubyLsp")
+      .get("rubyVersionManager")!;
+  }
+
+  async activateRuby() {
+    switch (this.managerConfiguration.manager) {
+      case "chruby":
+        await this.activateChruby();
+        break;
+      default:
+        await this.activateShadowenv();
+        break;
+    }
+  }
+
+  async activateShadowenv() {
+    await vscode.extensions
+      .getExtension("shopify.vscode-shadowenv")
+      ?.activate();
+  }
+
+  async activateChruby() {
+    if (!fs.existsSync(`${this.workingFolder}/.ruby-version`)) {
+      vscode.window.showErrorMessage(
+        "Attempted to activate chruby environment, but no .ruby-version file was found."
+      );
+      return;
+    }
+
+    if (!fs.existsSync(this.managerConfiguration.path)) {
+      vscode.window.showErrorMessage(
+        `Attempted to activate chruby environment, but the path provided does not exist (${this.managerConfiguration.path}).`
+      );
+      return;
+    }
+
+    const rubyVersion = await asyncReadFile(
+      `${this.workingFolder}/.ruby-version`
+    );
+
+    try {
+      const result = await asyncExec(
+        `source ${this.managerConfiguration.path} &&
+         chruby "${rubyVersion.toString().trim()}" &&
+         ruby -rjson -e "puts JSON.dump(ENV.to_h)"`
+      );
+
+      // eslint-disable-next-line no-process-env
+      process.env = JSON.parse(result.stdout);
+    } catch (error) {
+      vscode.window.showErrorMessage(
+        `Error when trying to activate chruby environment ${error}`
+      );
+    }
+  }
+}

--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -9,18 +9,18 @@ const asyncReadFile = promisify(fs.readFile);
 
 export class Ruby {
   private workingFolder: string;
-  private managerConfiguration: { [key: string]: string };
+  private versionManager: string;
 
   constructor() {
     this.workingFolder = vscode.workspace.workspaceFolders![0].uri.fsPath;
 
-    this.managerConfiguration = vscode.workspace
+    this.versionManager = vscode.workspace
       .getConfiguration("rubyLsp")
       .get("rubyVersionManager")!;
   }
 
   async activateRuby() {
-    switch (this.managerConfiguration.manager) {
+    switch (this.versionManager) {
       case "chruby":
         await this.activateChruby();
         break;
@@ -44,22 +44,34 @@ export class Ruby {
       return;
     }
 
-    if (!fs.existsSync(this.managerConfiguration.path)) {
-      vscode.window.showErrorMessage(
-        `Attempted to activate chruby environment, but the path provided does not exist (${this.managerConfiguration.path}).`
-      );
-      return;
-    }
-
     const rubyVersion = await asyncReadFile(
       `${this.workingFolder}/.ruby-version`
     );
 
     try {
+      let shellProfilePath;
+      // eslint-disable-next-line no-process-env
+      const shell = process.env.SHELL?.split("/").pop();
+      // eslint-disable-next-line no-process-env
+      const home = process.env.HOME;
+
+      switch (shell) {
+        case "fish":
+          shellProfilePath = `${home}/.config/fish/config.fish`;
+          break;
+        case "zsh":
+          shellProfilePath = `${home}/.zshrc`;
+          break;
+        default:
+          shellProfilePath = `${home}/.bashrc`;
+          break;
+      }
+
       const result = await asyncExec(
-        `source ${this.managerConfiguration.path} &&
+        `source ${shellProfilePath} &&
          chruby "${rubyVersion.toString().trim()}" &&
-         ruby -rjson -e "puts JSON.dump(ENV.to_h)"`
+         ruby -rjson -e "puts JSON.dump(ENV.to_h)"`,
+        { shell }
       );
 
       // eslint-disable-next-line no-process-env


### PR DESCRIPTION
First step towards #157

Add support for chruby. I'm proposing that we make the version manager and path to executable configurable, since trying to guess those can become quite messy.

For the chruby activation, we
1. Read the `.ruby-version` file to figure out which version to activate
2. Source the chruby script
3. Invoke the chruby script with the version we read
4. Echo all of the relevant environment variables. This is so that we can capture the results and insert them into the nodejs environment (otherwise all environment variable changes made by chruby are not applied to the parent process)

### Manual tests

1. On this branch, change your configuration to use chruby
```jsonc
"rubyLsp.rubyVersionManager": {
  "manager": "chruby",
  "path": "/opt/homebrew/opt/chruby/chruby.sh" // Find the actual path in your machine
}
```
2. Start the extension with F5 on the `ruby-lsp` repo
3. Verify you get an error prompt because no `.ruby-version` file exists
4. Create a `.ruby-version` file with some Ruby version (e.g.: `2.7.6`)
5. Reload the extension
6. Verify no errors pop up this time
7. In the output tab for the Ruby LSP, verify you get warnings about pattern matching being experimental (which are only printed in Ruby 2.7 and demonstrates that we selected the correct version)