### PR TITLE
Automate release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "The version to be released in the format X.Y.Z"
+        required: true
+        type: string
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        name: Checkout
+
+      - name: Bump version
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+
+          sed -i 's/\"version\":.*,/\"version\": \"${{ inputs.version }}\",/' package.json
+
+          git add package.json
+          git commit -m "Bump version to v${{ inputs.version }}"
+          git push origin main
+
+      - name: Create tag
+        run: |
+          git tag v${{ inputs.version }}
+          git push origin --tags
+
+      - name: Create release
+        uses: actions/github-script@v6
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          script: |
+            await github.rest.repos.createRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag_name: "refs/tags/v${{ inputs.version }}",
+              name: "v${{ inputs.version }}",
+              generate_release_notes: true
+            })


### PR DESCRIPTION
Attempt to fully automate the release of our VS Code extensions.

This GitHub action can only be triggered manually and accepts a version as an input in the format `0.1.2`. It will then
- Use `sed` to change the version in `package.json`
- Commit the changes and push to main
- Create a tag based on main using the selected version
- Push the tags
- Create a GitHub release using the recently created tag

Creating the GitHub release will trigger the [publish action](https://github.com/Shopify/vscode-ruby-lsp/blob/main/.github/workflows/publish.yml), which then packages the extension and publishes in the marketplace.

If this works, then releasing our extensions becomes just a matter of triggering the workflow with the desired version.