### PR TITLE
Enable the hover feature from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,11 @@
               "type": "boolean",
               "default": true
             },
+            "hover": {
+              "description": "Enable hover, which displays a widget with extra information when hovering over certain code",
+              "type": "boolean",
+              "default": true
+            },
             "inlayHint": {
               "description": "Enable inlay hints",
               "type": "boolean",
@@ -108,6 +113,7 @@
             "documentSymbols": true,
             "foldingRanges": true,
             "formatting": true,
+            "hover": true,
             "inlayHint": true,
             "onTypeFormatting": true,
             "selectionRanges": true,


### PR DESCRIPTION
This is a partner to Stan's work adding Rails documentation links on hover: https://github.com/Shopify/ruby-lsp/pull/313

See it in action:
https://user-images.githubusercontent.com/9601737/194160145-998efdac-7975-4a53-a3b3-e05d47839ce4.mov