### PR TITLE
Display progress when running bundle install

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -227,7 +227,21 @@ export default class Client {
     );
 
     if (response === "Run bundle install") {
-      await this.execInPath("bundle install");
+      await vscode.window.withProgress(
+        {
+          location: vscode.ProgressLocation.Notification,
+          title: "Installing gems",
+        },
+        async (progress) => {
+          try {
+            await this.execInPath("bundle install");
+          } catch {
+            // The progress dialog can't be closed by the user, so we have to guarantee that we catch errors
+            progress.report({ message: "Failed to install gems" });
+          }
+        }
+      );
+
       return false;
     }
 


### PR DESCRIPTION
Closes Shopify/ruby-lsp#1488

Use a window progress notification to inform the user when bundle install is running (and when it ends).

### Manual tests

1. Start the extension on this branch
2. Make sure gems are not all installed (you can achieve this with `gem uninstall syntax_tree` for example
3. Reload the extension debugger
4. Click on bundle install
5. Verify that a progress notification is shown and that it disappears after it's complete