### PR TITLE
Allow running the Ruby LSP server with YJIT

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,6 +128,11 @@
             "chruby"
           ],
           "default": "shadowenv"
+        },
+        "rubyLsp.yjit": {
+          "description": "Use YJIT to speed up the Ruby LSP server",
+          "type": "boolean",
+          "default": true
         }
       }
     },

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,4 +1,4 @@
-import { exec } from "child_process";
+import { exec, execSync } from "child_process";
 import { promisify } from "util";
 
 import * as vscode from "vscode";
@@ -32,11 +32,14 @@ export default class Client {
     this.workingFolder = vscode.workspace.workspaceFolders![0].uri.fsPath;
     this.telemetry = telemetry;
 
+    const env = this.getEnv();
+
     const executable: Executable = {
       command: "bundle",
       args: ["exec", "ruby-lsp"],
       options: {
         cwd: this.workingFolder,
+        env,
       },
     };
 
@@ -275,5 +278,32 @@ export default class Client {
       .get("enabledFeatures")!;
 
     return Object.keys(features).filter((key) => features[key]);
+  }
+
+  private getEnv() {
+    // eslint-disable-next-line no-process-env
+    const env = process.env;
+    const useYjit = vscode.workspace.getConfiguration("rubyLsp").get("yjit");
+
+    // Enabling YJIT only provides a performance benefit on Ruby 3.2.0 and above
+    if (!useYjit || env.RUBY_VERSION! < "3.2.0") {
+      return env;
+    }
+
+    // Check if the Ruby was compiled with YJIT since it's not required. The exec must be sync here because this is used
+    // in the constructor, which cannot be an async function
+    if (!execSync("ruby -v --yjit").toString().includes("+YJIT")) {
+      return env;
+    }
+
+    // RUBYOPT may be empty or it may contain bundler paths. In the second case, we must concat to avoid accidentally
+    // removing the paths from the env variable
+    if (env.RUBYOPT) {
+      env.RUBYOPT.concat(" --yjit");
+    } else {
+      env.RUBYOPT = "--yjit";
+    }
+
+    return env;
   }
 }


### PR DESCRIPTION
Starting on Ruby 3.2, YJIT provides a good performance boost on the Ruby LSP. This PR adds a new configuration to use YJIT and we should default to using it as long as the Ruby version is greater or equals to 3.2 and the Ruby was compiled with YJIT support.

The following chart is a comparison of the average time to execute requests with and without YJIT.

<img width="1832" alt="Ruby LSP + YJIT" src="https://user-images.githubusercontent.com/18742907/195918825-9d3d2285-7f33-4174-986f-4b6b8c79d40a.png">