### PR TITLE
Add support for ASDF, RVM, and Rbenv

### DIFF
--- a/package.json
+++ b/package.json
@@ -125,7 +125,10 @@
           "type": "string",
           "enum": [
             "shadowenv",
-            "chruby"
+            "chruby",
+            "asdf",
+            "rbenv",
+            "rvm"
           ],
           "default": "shadowenv"
         },

--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -64,7 +64,7 @@ export class Ruby {
       }
 
       const result = await asyncExec(
-        `source ${shellProfilePath} && ${command} ruby -rjson -e "puts JSON.dump(ENV.to_h)"`,
+        `source ${shellProfilePath} > /dev/null 2>&1 && ${command} ruby -rjson -e "puts JSON.dump(ENV.to_h)"`,
         { shell, cwd: this.workingFolder }
       );
 

--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -21,16 +21,16 @@ export class Ruby {
     try {
       switch (this.versionManager) {
         case "asdf":
-          await this.activate("asdf exec");
+          await this.activate("asdf exec ruby");
           break;
         case "chruby":
           await this.activateChruby();
           break;
         case "rbenv":
-          await this.activate("rbenv exec");
+          await this.activate("rbenv exec ruby");
           break;
         case "rvm":
-          await this.activate("rvm exec");
+          await this.activate("rvm-auto-ruby");
           break;
         default:
           await this.activateShadowenv();
@@ -51,10 +51,10 @@ export class Ruby {
 
   async activateChruby() {
     const rubyVersion = await this.readRubyVersion();
-    await this.activate(`chruby-exec "${rubyVersion}" --`);
+    await this.activate(`chruby-exec "${rubyVersion}" -- ruby`);
   }
 
-  async activate(command: string) {
+  async activate(ruby: string) {
     let shellProfilePath;
     // eslint-disable-next-line no-process-env
     const shell = process.env.SHELL?.split("/").pop();
@@ -74,7 +74,7 @@ export class Ruby {
     }
 
     const result = await asyncExec(
-      `source ${shellProfilePath} > /dev/null 2>&1 && ${command} ruby -rjson -e "puts JSON.dump(ENV.to_h)"`,
+      `source ${shellProfilePath} > /dev/null 2>&1 && ${ruby} -rjson -e "puts JSON.dump(ENV.to_h)"`,
       { shell, cwd: this.workingFolder }
     );
 

--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -1,6 +1,7 @@
 import { exec } from "child_process";
 import { promisify } from "util";
 import { readFile } from "fs/promises";
+
 import * as vscode from "vscode";
 
 const asyncExec = promisify(exec);

--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -36,6 +36,8 @@ export class Ruby {
           await this.activateShadowenv();
           break;
       }
+
+      this.displayRubyVersion();
     } catch (error: any) {
       vscode.window.showErrorMessage(
         `Failed to activate ${this.versionManager} environment: ${error.message}`
@@ -80,6 +82,11 @@ export class Ruby {
 
     // eslint-disable-next-line no-process-env
     process.env = JSON.parse(result.stdout);
+  }
+
+  private async displayRubyVersion() {
+    const rubyVersion = await asyncExec('ruby -e "puts RUBY_VERSION"');
+    vscode.window.setStatusBarMessage(`Ruby ${rubyVersion.stdout.trim()}`);
   }
 
   private async readRubyVersion() {

--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -19,8 +19,17 @@ export class Ruby {
 
   async activateRuby() {
     switch (this.versionManager) {
+      case "asdf":
+        await this.activate("asdf", "asdf exec");
+        break;
       case "chruby":
-        await this.activateChruby();
+        await this.activate("chruby", "chruby-exec");
+        break;
+      case "rbenv":
+        await this.activate("rbenv", "rbenv exec");
+        break;
+      case "rvm":
+        await this.activate("rvm", "rvm exec");
         break;
       default:
         await this.activateShadowenv();
@@ -34,7 +43,7 @@ export class Ruby {
       ?.activate();
   }
 
-  async activateChruby() {
+  async activate(name: string, command: string) {
     try {
       let shellProfilePath;
       // eslint-disable-next-line no-process-env
@@ -55,8 +64,7 @@ export class Ruby {
       }
 
       const result = await asyncExec(
-        `source ${shellProfilePath} &&
-         chruby-exec ruby -rjson -e "puts JSON.dump(ENV.to_h)"`,
+        `source ${shellProfilePath} && ${command} ruby -rjson -e "puts JSON.dump(ENV.to_h)"`,
         { shell, cwd: this.workingFolder }
       );
 
@@ -64,7 +72,7 @@ export class Ruby {
       process.env = JSON.parse(result.stdout);
     } catch (error) {
       vscode.window.showErrorMessage(
-        `Error when trying to activate chruby environment ${error}`
+        `Error when trying to activate ${name} environment ${error}`
       );
     }
   }

--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -1,11 +1,9 @@
 import { exec } from "child_process";
 import { promisify } from "util";
-import * as fs from "fs";
 
 import * as vscode from "vscode";
 
 const asyncExec = promisify(exec);
-const asyncReadFile = promisify(fs.readFile);
 
 export class Ruby {
   private workingFolder: string;
@@ -37,17 +35,6 @@ export class Ruby {
   }
 
   async activateChruby() {
-    if (!fs.existsSync(`${this.workingFolder}/.ruby-version`)) {
-      vscode.window.showErrorMessage(
-        "Attempted to activate chruby environment, but no .ruby-version file was found."
-      );
-      return;
-    }
-
-    const rubyVersion = await asyncReadFile(
-      `${this.workingFolder}/.ruby-version`
-    );
-
     try {
       let shellProfilePath;
       // eslint-disable-next-line no-process-env
@@ -69,9 +56,8 @@ export class Ruby {
 
       const result = await asyncExec(
         `source ${shellProfilePath} &&
-         chruby "${rubyVersion.toString().trim()}" &&
-         ruby -rjson -e "puts JSON.dump(ENV.to_h)"`,
-        { shell }
+         chruby-exec ruby -rjson -e "puts JSON.dump(ENV.to_h)"`,
+        { shell, cwd: this.workingFolder }
       );
 
       // eslint-disable-next-line no-process-env


### PR DESCRIPTION
I'm leveraging the `exec` feature that most version managers include to load the environment. This feature will automatically detect the appropriate version to use based on any project-local configuration file (e.g. `.ruby-version` or `.tool-versions`). Shadowenv is kind of the oddball here (because of `vscode-shadowenv`), and I wonder if we could just use `shadowenv exec` as well.

I've created a draft PR because I'm hoping that someone might suggest a reasonable approach to testing this feature. I personally use ASDF, and I've manually tested that it works.

As a side-note, I wonder if mutating `process.env` might have some unintended consequences. Instead, using the `exec` feature (e.g. `asdf exec`) when executing client commands might be a more reliable approach. For example, that interface might look like this:

```javascript
const ruby = new Ruby();
await ruby.executeCommand('bundle install'); // would source the profile and run `asdf exec bundle install`
```

This approach would allow the delays in `extension.ts` to be removed.