### PR TITLE
Fix  settings.json example for chruby in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,7 @@ configuration script (e.g.: ~/.bashrc, ~/.zshrc) and that the SHELL environment 
 default shell.
 
 ```jsonc
-"rubyLsp.rubyVersionManager": {
-  "manager": "chruby", // The handle for the version manager (e.g.: chruby, shadowenv)
-}
+"rubyLsp.rubyVersionManager": "chruby" // The handle for the version manager (e.g.: chruby, shadowenv)
 ```
 
 ### Commands


### PR DESCRIPTION
https://github.com/Shopify/vscode-ruby-lsp/pull/226 introduced chruby support (yay!) but seems the readme was not updated once the implementation changed to not require configuring the path.