### PR TITLE
Create status items

### DIFF
--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -6,10 +6,12 @@ import * as vscode from "vscode";
 const asyncExec = promisify(exec);
 
 export async function isGemMissing(): Promise<boolean> {
-  const bundledGems = await execInPath("bundle list");
-  const hasRubyLsp = bundledGems.stdout.includes("ruby-lsp");
-
-  return !hasRubyLsp;
+  try {
+    await execInPath("bundle show ruby-lsp");
+    return false;
+  } catch {
+    return true;
+  }
 }
 
 export async function isGemOutdated(): Promise<boolean> {
@@ -23,8 +25,9 @@ export async function isGemOutdated(): Promise<boolean> {
 }
 
 export async function addGem(): Promise<void> {
-  await execInPath("bundle add ruby-lsp --group=development");
-  await execInPath("bundle install");
+  await execInPath(
+    "bundle add ruby-lsp --group=development --require=false && bundle install"
+  );
 }
 
 export async function updateGem(): Promise<{ stdout: string; stderr: string }> {
@@ -32,19 +35,12 @@ export async function updateGem(): Promise<{ stdout: string; stderr: string }> {
 }
 
 export async function bundleCheck(): Promise<boolean> {
-  let bundlerCheck: string;
-
   try {
-    bundlerCheck = (await execInPath("bundle check")).stdout;
+    await execInPath("bundle check");
+    return true;
   } catch {
-    bundlerCheck = "";
-  }
-
-  if (bundlerCheck.includes("The Gemfile's dependencies are satisfied")) {
     return false;
   }
-
-  return true;
 }
 
 export async function bundleInstall(): Promise<{

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -5,6 +5,13 @@ import * as vscode from "vscode";
 
 const asyncExec = promisify(exec);
 
+export async function isGemMissing(): Promise<boolean> {
+  const bundledGems = await execInPath("bundle list");
+  const hasRubyLsp = bundledGems.stdout.includes("ruby-lsp");
+
+  return !hasRubyLsp;
+}
+
 export async function isGemOutdated(): Promise<boolean> {
   try {
     await execInPath("bundle outdated ruby-lsp");
@@ -15,8 +22,36 @@ export async function isGemOutdated(): Promise<boolean> {
   return false;
 }
 
+export async function addGem(): Promise<void> {
+  await execInPath("bundle add ruby-lsp --group=development");
+  await execInPath("bundle install");
+}
+
 export async function updateGem(): Promise<{ stdout: string; stderr: string }> {
   return execInPath("bundle update ruby-lsp");
+}
+
+export async function bundleCheck(): Promise<boolean> {
+  let bundlerCheck: string;
+
+  try {
+    bundlerCheck = (await execInPath("bundle check")).stdout;
+  } catch {
+    bundlerCheck = "";
+  }
+
+  if (bundlerCheck.includes("The Gemfile's dependencies are satisfied")) {
+    return false;
+  }
+
+  return true;
+}
+
+export async function bundleInstall(): Promise<{
+  stdout: string;
+  stderr: string;
+}> {
+  return execInPath("bundle install");
 }
 
 async function execInPath(

--- a/src/client.ts
+++ b/src/client.ts
@@ -157,9 +157,7 @@ export default class Client {
   }
 
   async restart() {
-    await this.statusItem.updateStatus(ServerCommand.Stop);
     await this.stop();
-    await this.statusItem.updateStatus(ServerCommand.Start);
     await this.start();
   }
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -141,10 +141,6 @@ export default class Client {
       this.clientOptions
     );
 
-    if ((await this.gemNotInstalled()) || (await this.gemMissing())) {
-      return;
-    }
-
     this.client.onTelemetry(this.telemetry.sendEvent.bind(this.telemetry));
     await this.client.start();
   }

--- a/src/client.ts
+++ b/src/client.ts
@@ -157,7 +157,9 @@ export default class Client {
   }
 
   async restart() {
+    await this.statusItem.updateStatus(ServerCommand.Stop);
     await this.stop();
+    await this.statusItem.updateStatus(ServerCommand.Start);
     await this.start();
   }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,7 +3,6 @@ import * as vscode from "vscode";
 import Client from "./client";
 import { Telemetry } from "./telemetry";
 import { Ruby } from "./ruby";
-import { isGemOutdated, updateGem } from "./bundler";
 
 let client: Client;
 
@@ -16,59 +15,10 @@ export async function activate(context: vscode.ExtensionContext) {
 
   // Adding this delay guarantees that the Ruby environment is activated before trying to start the server
   await client.start();
-
-  activateGemOutdatedButton(context);
 }
 
 export async function deactivate(): Promise<void> {
   if (client) {
     return client.stop();
   }
-}
-
-async function activateGemOutdatedButton(context: vscode.ExtensionContext) {
-  const gemOutdated = await isGemOutdated();
-  if (!gemOutdated) {
-    return;
-  }
-
-  const commandId = "updateOutdatedGem";
-
-  const gemOutdatedButton = vscode.window.createStatusBarItem(
-    vscode.StatusBarAlignment.Left,
-    0
-  );
-
-  gemOutdatedButton.text = "$(plug) Update Ruby LSP";
-  gemOutdatedButton.tooltip =
-    "The ruby-lsp gem is not up-to-date. Press this button to install the latest version of the gem.";
-  gemOutdatedButton.command = commandId;
-
-  context.subscriptions.push(
-    vscode.commands.registerCommand(commandId, async () => {
-      gemOutdatedButton.text = "$(loading~spin) Updating Ruby LSP";
-      const result = await updateGem();
-
-      if (result.stderr.length > 0) {
-        gemOutdatedButton.text = "$(close) Ruby LSP Update Failed";
-
-        if (
-          result.stderr.includes(
-            "Bundler attempted to update ruby-lsp but its version stayed the same"
-          )
-        ) {
-          vscode.window.showWarningMessage(
-            "Could not update the ruby-lsp gem. Is the version in the Gemfile pinned?"
-          );
-        } else {
-          vscode.window.showErrorMessage("Failed to update gem.");
-        }
-      } else {
-        vscode.window.showInformationMessage("Successfully updated Ruby LSP.");
-        gemOutdatedButton.hide();
-      }
-    })
-  );
-
-  gemOutdatedButton.show();
 }

--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -72,6 +72,12 @@ export class Ruby {
     process.env = JSON.parse(result.stdout);
   }
 
+  private async displayRubyVersion() {
+    const rubyVersion = await asyncExec('ruby -e "puts RUBY_VERSION"');
+    this.rubyVersion = rubyVersion.stdout.trim();
+    vscode.window.setStatusBarMessage(`Ruby ${this.rubyVersion}`);
+  }
+
   private async readRubyVersion() {
     try {
       const version = await readFile(

--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -72,12 +72,6 @@ export class Ruby {
     process.env = JSON.parse(result.stdout);
   }
 
-  private async displayRubyVersion() {
-    const rubyVersion = await asyncExec('ruby -e "puts RUBY_VERSION"');
-    this.rubyVersion = rubyVersion.stdout.trim();
-    vscode.window.setStatusBarMessage(`Ruby ${this.rubyVersion}`);
-  }
-
   private async readRubyVersion() {
     try {
       const version = await readFile(

--- a/src/status.ts
+++ b/src/status.ts
@@ -9,6 +9,16 @@ export enum ServerCommand {
   Restart = "ruby-lsp.restart",
 }
 
+const STOPPED_SERVER_OPTIONS = [
+  { label: "Ruby LSP: Start", description: "ruby-lsp.start" },
+  { label: "Ruby LSP: Restart", description: "ruby-lsp.restart" },
+];
+
+const STARTED_SERVER_OPTIONS = [
+  { label: "Ruby LSP: Stop", description: "ruby-lsp.stop" },
+  { label: "Ruby LSP: Restart", description: "ruby-lsp.restart" },
+];
+
 export class StatusItem {
   private context: vscode.ExtensionContext;
   private ruby: Ruby;
@@ -31,8 +41,9 @@ export class StatusItem {
     );
 
     this.serverStatus.command = {
-      title: "Restart server",
+      title: "Configure",
       command: "rubyLsp.serverOptions",
+      arguments: [STARTED_SERVER_OPTIONS],
     };
 
     this.yjitStatus = vscode.languages.createLanguageStatusItem(
@@ -52,7 +63,7 @@ export class StatusItem {
     switch (status) {
       case ServerCommand.Start: {
         this.serverStatus.text = "Ruby LSP: Running...";
-        this.serverStatus.command!.title = "Stop Server";
+        this.serverStatus.command!.arguments = [STARTED_SERVER_OPTIONS];
 
         this.activateGemOutdatedButton();
 
@@ -60,99 +71,61 @@ export class StatusItem {
       }
       case ServerCommand.Stop: {
         this.serverStatus.text = "Ruby LSP: Stopped";
-        this.serverStatus.command!.title = "Start Server";
+        this.serverStatus.command!.arguments = [STOPPED_SERVER_OPTIONS];
 
         break;
       }
       case ServerCommand.Restart: {
         this.serverStatus.text = "Ruby LSP: Error";
         this.serverStatus.severity = vscode.LanguageStatusSeverity?.Error;
-        this.serverStatus.command!.title = "Restart Server";
+        this.serverStatus.command!.arguments = [STOPPED_SERVER_OPTIONS];
       }
     }
   }
 
   public async installGems(): Promise<boolean> {
-    if (!(await Bundler.bundleCheck())) {
-      this.serverStatus.text = "Ruby LSP: Error";
-      this.serverStatus.severity = vscode.LanguageStatusSeverity?.Error;
+    if (await Bundler.bundleCheck()) return false;
 
-      const status: vscode.LanguageStatusItem = this.createStatusItem(
-        "installGems",
-        "Ruby LSP: The gems in the bundle are not installed.",
-        vscode.LanguageStatusSeverity?.Error
-      );
+    this.updateStatus(ServerCommand.Restart);
 
-      const commandId = "rubyLsp.installGems";
+    const status: vscode.LanguageStatusItem = this.createStatusItem(
+      "installGems",
+      "Ruby LSP: The gems in the bundle are not installed.",
+      vscode.LanguageStatusSeverity?.Error
+    );
 
-      this.context.subscriptions.push(
-        vscode.commands.registerCommand(commandId, () => {
-          status.text = "Ruby LSP: Installing gems...";
-          status.busy = true;
-          Bundler.bundleInstall()
-            .then(() => {
-              status.dispose();
-              this.addMissingGem();
-            })
-            .catch(() => {
-              status.dispose();
-              this.createStatusItem(
-                "installFail",
-                "Ruby LSP: Failed to install gems.",
-                vscode.LanguageStatusSeverity?.Error
-              );
-            });
-        })
-      );
-
-      status.command = {
-        title: "Run bundle install",
-        command: commandId,
-      };
-      return true;
-    }
-    return false;
+    status.command = {
+      title: "Run bundle install",
+      command: "rubyLsp.installGems",
+      arguments: [status],
+    };
+    return true;
   }
 
   public async addMissingGem(): Promise<boolean> {
-    if (await Bundler.isGemMissing()) {
-      this.serverStatus.text = "Ruby LSP: Error";
-      this.serverStatus.severity = vscode.LanguageStatusSeverity?.Error;
+    if (!(await Bundler.isGemMissing())) return false;
 
-      const status: vscode.LanguageStatusItem = this.createStatusItem(
-        "addMissingGem",
-        "Ruby LSP: Bundle Add",
-        vscode.LanguageStatusSeverity?.Error
-      );
+    this.updateStatus(ServerCommand.Restart);
 
-      const commandId = "rubyLsp.addMissingGem";
+    const status: vscode.LanguageStatusItem = this.createStatusItem(
+      "addMissingGem",
+      "Ruby LSP: Bundle Add",
+      vscode.LanguageStatusSeverity?.Error
+    );
 
-      this.context.subscriptions.push(
-        vscode.commands.registerCommand(commandId, () => {
-          status.text = "Ruby LSP: Adding gem...";
-          status.busy = true;
-          Bundler.addGem()
-            .then(() => status.dispose())
-            .catch(() => {});
-        })
-      );
+    status.command = {
+      title: "Run bundle add and install",
+      command: "rubyLsp.addMissingGem",
+      arguments: [status],
+    };
 
-      status.command = {
-        title: "Run bundle add and install",
-        command: "ruby-lsp.addMissingGem",
-      };
-      return true;
-    }
-    return false;
+    return true;
   }
 
   private async activateGemOutdatedButton() {
     const gemOutdated = await Bundler.isGemOutdated();
-    if (!gemOutdated) {
-      return;
-    }
 
-    const commandId = "updateOutdatedGem";
+    if (!gemOutdated) return;
 
     const status: vscode.LanguageStatusItem = this.createStatusItem(
       "updateGem",
@@ -160,40 +133,10 @@ export class StatusItem {
       vscode.LanguageStatusSeverity?.Warning
     );
 
-    this.context.subscriptions.push(
-      vscode.commands.registerCommand(commandId, async () => {
-        status.text = "Ruby LSP: Updating Ruby LSP...";
-        status.busy = true;
-
-        const result = await Bundler.updateGem();
-
-        if (result.stderr.length > 0) {
-          status.text = "Ruby LSP: Update failed";
-          status.command = {
-            title: "Try again",
-            command: commandId,
-          };
-
-          if (
-            result.stderr.includes(
-              "Bundler attempted to update ruby-lsp but its version stayed the same"
-            )
-          ) {
-            vscode.window.showWarningMessage(
-              "Could not update the ruby-lsp gem. Is the version in the Gemfile pinned?"
-            );
-          } else {
-            vscode.window.showErrorMessage("Failed to update gem.");
-          }
-        } else {
-          status.dispose();
-        }
-      })
-    );
-
     status.command = {
       title: "Update",
-      command: commandId,
+      command: "rubyLsp.updateOutdatedGem",
+      arguments: [status],
     };
   }
 
@@ -258,20 +201,81 @@ export class StatusItem {
     );
 
     this.context.subscriptions.push(
-      vscode.commands.registerCommand("rubyLsp.serverOptions", async () => {
-        const result = await vscode.window.showQuickPick(
-          [
-            { label: "Ruby LSP: Start", description: "ruby-lsp.start" },
-            { label: "Ruby LSP: Stop", description: "ruby-lsp.stop" },
-            { label: "Ruby LSP: Restart", description: "ruby-lsp.restart" },
-          ],
-          {
+      vscode.commands.registerCommand(
+        "rubyLsp.serverOptions",
+        async (options: [{ label: string; description: string }]) => {
+          const result = await vscode.window.showQuickPick(options, {
             placeHolder: "Select server action",
-          }
-        );
+          });
 
-        if (result !== undefined)
-          await vscode.commands.executeCommand(result.description);
+          if (result !== undefined)
+            await vscode.commands.executeCommand(result.description);
+        }
+      )
+    );
+
+    this.context.subscriptions.push(
+      vscode.commands.registerCommand("rubyLsp.addMissingGem", (status) => {
+        status.text = "Ruby LSP: Adding gem...";
+        status.busy = true;
+        Bundler.addGem()
+          .then(() => status.dispose())
+          .catch(() => {});
+      })
+    );
+
+    this.context.subscriptions.push(
+      vscode.commands.registerCommand(
+        "rubyLsp.updateOutdatedGem",
+        async (status) => {
+          status.text = "Ruby LSP: Updating Ruby LSP...";
+          status.busy = true;
+
+          const result = await Bundler.updateGem();
+
+          if (result.stderr.length > 0) {
+            status.text = "Ruby LSP: Update failed";
+            status.command = {
+              title: "Try again",
+              command: "rubyLsp.updateOutdatedGem",
+            };
+
+            if (
+              result.stderr.includes(
+                "Bundler attempted to update ruby-lsp but its version stayed the same"
+              )
+            ) {
+              vscode.window.showWarningMessage(
+                "Could not update the ruby-lsp gem. Is the version in the Gemfile pinned?"
+              );
+            } else {
+              vscode.window.showErrorMessage("Failed to update gem.");
+            }
+          } else {
+            status.dispose();
+          }
+        }
+      )
+    );
+
+    this.context.subscriptions.push(
+      vscode.commands.registerCommand("rubyLsp.installGems", (status) => {
+        status.text = "Ruby LSP: Installing gems...";
+        status.busy = true;
+        Bundler.bundleInstall()
+          .then(() => {
+            status.dispose();
+            this.addMissingGem();
+            vscode.commands.executeCommand(ServerCommand.Restart);
+          })
+          .catch(() => {
+            status.dispose();
+            this.createStatusItem(
+              "installFail",
+              "Ruby LSP: Failed to install gems.",
+              vscode.LanguageStatusSeverity?.Error
+            );
+          });
       })
     );
   }

--- a/src/status.ts
+++ b/src/status.ts
@@ -1,0 +1,267 @@
+import * as vscode from "vscode";
+
+import {
+  isGemMissing,
+  addGem,
+  bundleCheck,
+  bundleInstall,
+  isGemOutdated,
+  updateGem,
+} from "./bundler";
+import { Ruby } from "./ruby";
+
+export const enum ServerCommand {
+  Start = "ruby-lsp.start",
+  Stop = "ruby-lsp.stop",
+  Error = "ruby-lsp.restart",
+}
+
+export class StatusItem {
+  private context: vscode.ExtensionContext;
+  private ruby: Ruby;
+  private selector: vscode.DocumentSelector;
+  private serverStatus: vscode.LanguageStatusItem;
+
+  constructor(context: vscode.ExtensionContext, ruby: Ruby) {
+    this.context = context;
+    this.ruby = ruby;
+    this.selector = {
+      scheme: "file",
+      language: "ruby",
+    };
+
+    this.serverStatus = this.createStatusItem(
+      "serverStatus",
+      "Ruby LSP: Starting...",
+      vscode.LanguageStatusSeverity?.Warning
+    );
+
+    this.serverStatus.command = {
+      title: "Restart server",
+      command: ServerCommand.Error,
+    };
+
+    this.createYjitStatus(this.ruby);
+    this.createRubyStatus(this.ruby);
+  }
+
+  public async updateStatus(status: ServerCommand) {
+    if (this.serverStatus) {
+      this.serverStatus.dispose();
+    }
+
+    switch (status) {
+      case ServerCommand.Start: {
+        this.serverStatus = this.createStatusItem(
+          "serverStatus",
+          "Ruby LSP: Running...",
+          vscode.LanguageStatusSeverity?.Warning
+        );
+
+        this.serverStatus.command = {
+          title: "Stop Server",
+          command: ServerCommand.Stop,
+        };
+
+        this.activateGemOutdatedButton();
+
+        break;
+      }
+      case ServerCommand.Stop: {
+        this.serverStatus = this.createStatusItem(
+          "serverStatus",
+          "Ruby LSP: Stopped",
+          vscode.LanguageStatusSeverity?.Warning
+        );
+
+        this.serverStatus.command = {
+          title: "Start Server",
+          command: ServerCommand.Start,
+        };
+
+        break;
+      }
+      case ServerCommand.Error: {
+        this.serverStatus = this.createStatusItem(
+          "serverStatus",
+          "Ruby LSP: Error",
+          vscode.LanguageStatusSeverity?.Error
+        );
+
+        this.serverStatus.command = {
+          title: "Restart Server",
+          command: ServerCommand.Error,
+        };
+      }
+    }
+  }
+
+  public async installGems(): Promise<boolean> {
+    if (await bundleCheck()) {
+      this.updateStatus(ServerCommand.Error);
+      const status: vscode.LanguageStatusItem = this.createStatusItem(
+        "installGems",
+        "Ruby LSP: The gems in the bundle are not installed.",
+        vscode.LanguageStatusSeverity?.Error
+      );
+
+      this.context.subscriptions.push(
+        vscode.commands.registerCommand("ruby-lsp.installGems", () => {
+          status.text = "Ruby LSP: Installing gems...";
+          status.command = undefined;
+          status.busy = true;
+          bundleInstall()
+            .then(() => {
+              status.dispose();
+              this.addMissingGem();
+            })
+            .catch(() => {
+              status.dispose();
+              this.createStatusItem(
+                "installFail",
+                "Ruby LSP: Failed to install gems.",
+                vscode.LanguageStatusSeverity?.Error
+              );
+            });
+        })
+      );
+
+      status.command = {
+        title: "Run bundle install",
+        command: "ruby-lsp.installGems",
+      };
+      return true;
+    }
+    return false;
+  }
+
+  public async addMissingGem(): Promise<boolean> {
+    if (await isGemMissing()) {
+      this.updateStatus(ServerCommand.Error);
+      const status: vscode.LanguageStatusItem = this.createStatusItem(
+        "addMissingGem",
+        "Ruby LSP: Bundle Add",
+        vscode.LanguageStatusSeverity?.Error
+      );
+
+      this.context.subscriptions.push(
+        vscode.commands.registerCommand("ruby-lsp.addMissingGem", () => {
+          status.text = "Ruby LSP: Adding gem...";
+          status.command = undefined;
+          status.busy = true;
+          addGem()
+            .then(() => status.dispose())
+            .catch(() => {});
+        })
+      );
+
+      status.command = {
+        title: "Run bundle add and install",
+        command: "ruby-lsp.addMissingGem",
+      };
+      return true;
+    }
+    return false;
+  }
+
+  private async activateGemOutdatedButton() {
+    const gemOutdated = await isGemOutdated();
+    if (!gemOutdated) {
+      return;
+    }
+
+    const commandId = "updateOutdatedGem";
+
+    const status: vscode.LanguageStatusItem = this.createStatusItem(
+      "updateGem",
+      "Ruby LSP: The gem is not up-to-date",
+      vscode.LanguageStatusSeverity?.Warning
+    );
+
+    this.context.subscriptions.push(
+      vscode.commands.registerCommand(commandId, async () => {
+        status.text = "Ruby LSP: Updating Ruby LSP";
+        status.busy = true;
+        status.command = undefined;
+
+        const result = await updateGem();
+
+        if (result.stderr.length > 0) {
+          status.text = "Ruby LSP: Update failed";
+          status.command = {
+            title: "Try again",
+            command: commandId,
+          };
+
+          if (
+            result.stderr.includes(
+              "Bundler attempted to update ruby-lsp but its version stayed the same"
+            )
+          ) {
+            vscode.window.showWarningMessage(
+              "Could not update the ruby-lsp gem. Is the version in the Gemfile pinned?"
+            );
+          } else {
+            vscode.window.showErrorMessage("Failed to update gem.");
+          }
+        } else {
+          status.dispose();
+        }
+      })
+    );
+
+    status.command = {
+      title: "Update",
+      command: commandId,
+    };
+  }
+
+  private createYjitStatus(ruby: Ruby) {
+    const useYjit = vscode.workspace.getConfiguration("rubyLsp").get("yjit");
+
+    let [major, minor]: number[] = [0, 0];
+
+    if (this.ruby.rubyVersion) {
+      [major, minor] = this.ruby.rubyVersion.split(".").map(Number);
+    }
+
+    const yjit: vscode.LanguageStatusItem =
+      vscode.languages.createLanguageStatusItem("yjit", this.selector);
+    yjit.name = "Ruby LSP Status";
+
+    if (useYjit && ruby.yjitEnabled && [major, minor] >= [3, 2]) {
+      yjit.text = "Ruby LSP: YJIT is in use";
+    } else {
+      yjit.text = "Ruby LSP: YJIT is not in use";
+      if ([major, minor] >= [3, 2]) {
+        yjit.severity = vscode.LanguageStatusSeverity?.Warning;
+        yjit.command = {
+          title: "Enable it",
+          command: "",
+        };
+      } else {
+        yjit.severity = vscode.LanguageStatusSeverity?.Information;
+      }
+    }
+  }
+
+  private createRubyStatus(ruby: Ruby) {
+    const rubyVersion: vscode.LanguageStatusItem =
+      vscode.languages.createLanguageStatusItem("rubyVersion", this.selector);
+    rubyVersion.name = "Ruby LSP Status";
+    rubyVersion.text = `Using Ruby ${ruby.rubyVersion}`;
+  }
+
+  private createStatusItem(
+    id: string,
+    text: string,
+    severity: vscode.LanguageStatusSeverity
+  ): vscode.LanguageStatusItem {
+    const status: vscode.LanguageStatusItem =
+      vscode.languages.createLanguageStatusItem(id, this.selector);
+    status.name = "Ruby LSP Status";
+    status.text = text;
+    status.severity = severity;
+    return status;
+  }
+}


### PR DESCRIPTION
Related to #262 

### Features 
This PR creates language status items to:
- Warn users if the server gem has not been installed
  - If it hasn't been installed, there's an option to run `bundle install`
- Warn users if `ruby-lsp` is not on the bundle list
  - If it hasn't been added, there's an option to run `bundle add`
- Warn users if `ruby-lsp` is out-of-date and prompt them to update
- If the server is running, allow users to stop it
- If the server is stopped, allow users to start it
- If the server has errored, allow users to restart it
  - This feature is not totally complete because I think it will require some refactoring in `client.ts` and the PR is already pretty big so I felt this would be best in a separate PR
 - Show what Ruby version is being used
 - Show if YJIT is being used with the LSP
   - If the user is using Ruby  >= 3.2 and has YJIT set up, they have the option to toggle YJIT.

### Appearance
To view the language status items, you must have a Ruby file open and you must hover over the `{ }` next to "Ruby"

<img width="345" alt="Screenshot 2023-01-11 at 1 29 54 PM" src="https://user-images.githubusercontent.com/38566184/211888602-914dfa67-1905-436b-b9b7-caab2bdf029b.png">
<img width="726" alt="Screenshot 2023-01-11 at 2 35 51 PM" src="https://user-images.githubusercontent.com/38566184/211901207-73eefd94-10a1-4895-89e2-1ad1b8c6a247.png">
<img width="518" alt="Screenshot 2022-12-14 at 8 29 34 AM" src="https://user-images.githubusercontent.com/38566184/207607994-ef6a685f-c5a6-4950-99c2-f061ba020436.png">
<img width="389" alt="Screenshot 2023-01-11 at 2 41 15 PM" src="https://user-images.githubusercontent.com/38566184/211902273-eb8d5172-5296-4549-a92d-2c7100d5ec11.png">


**Note:** You can pin language status items and they will appear in your status bar. Once you pin it, the pin will remain and even if the language status item is disposed of, it'll be pinned if it is created again. However, the API does not currently allow developers to pin items automatically so this must be done by the user. Clicking the pinned language status item will trigger its command. It's nice because developers can customize what they'd like so their status bar doesn't get too noisy.

### Test
1. Open this branch in VSCode
2. Run the branch using the "Debug and Run" tab on the Workbench
3. Open a Ruby file
4. Check out the language status items by hovering over the `{ }` next to Ruby (see images above)
5. Try out starting and stopping the server (You can see that this is working by looking at the "Debug Console" in your `vscode-ruby-lsp` window)
6. Create some errors
    - Run `bundle remove ruby-lsp` in your repository that you're using to debug and then use the language status item to run `bundle add`
    - Run `gem uninstall ruby-lsp`, reload the debugging window, use the language status item to run `bundle install`
    - Install an older version of `ruby-lsp` and uninstall the most recent version, reload, and use the language status item to install the latest version (You may get a "The gems in this bundle are not installed" error if the version of `ruby-lsp` is specified in the `Gemfile` to be `~> 0.3.7`)
7. Toggle YJIT
    - Ensure you have YJIT
    - Open a project using Ruby `>= 3.2.0` (e.g., `ruby-lsp`)
    - You should see the option from the first screenshot. You can toggle from the status item.

