### PR TITLE
Add "none" as option for Ruby Version Manager

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,8 @@
             "chruby",
             "asdf",
             "rbenv",
-            "rvm"
+            "rvm",
+            "none"
           ],
           "default": "shadowenv"
         },

--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -36,7 +36,6 @@ export class Ruby {
           await this.activate("rvm-auto-ruby");
           break;
         case "none":
-          await this.activate("ruby");
           break;
         default:
           await this.activateShadowenv();

--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -35,6 +35,9 @@ export class Ruby {
         case "rvm":
           await this.activate("rvm-auto-ruby");
           break;
+        case "none":
+          await this.activate("ruby");
+          break;
         default:
           await this.activateShadowenv();
           break;


### PR DESCRIPTION
Fixes #335

Allows to use the ruby version provided within the system. This is especially useful for docker-based local dev environments.