### PR TITLE
Make sure we stop the current client before restarting

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -127,15 +127,15 @@ export default class Client {
   }
 
   async start() {
-    if ((await this.gemNotInstalled()) || (await this.gemMissing())) {
-      return;
-    }
-
     this.client = new LanguageClient(
       LSP_NAME,
       this.serverOptions,
       this.clientOptions
     );
+
+    if ((await this.gemNotInstalled()) || (await this.gemMissing())) {
+      return;
+    }
 
     this.client.onTelemetry(this.telemetry.sendEvent.bind(this.telemetry));
     await this.client.start();
@@ -275,9 +275,15 @@ export default class Client {
     );
     this.context.subscriptions.push(watcher);
 
-    watcher.onDidChange(() => this.restart());
-    watcher.onDidCreate(() => this.restart());
-    watcher.onDidDelete(() => this.restart());
+    watcher.onDidChange(async () => {
+      await this.restart();
+    });
+    watcher.onDidCreate(async () => {
+      await this.restart();
+    });
+    watcher.onDidDelete(async () => {
+      await this.restart();
+    });
   }
 
   private listOfEnabledFeatures(): string[] {


### PR DESCRIPTION
Closes #348

Given this scenario:
1. User starts the Ruby LSP on a project that needs bundle install
2. Instead of clicking on bundle install, run bundle install through the terminal
3. Change `Gemfile`, `Gemfile.lock` or any other watched files
4. This would trigger a restart and spawn a server process (which would work because gems are now installed)
5. After this process has been spawned, click `bundle install` on the dialogue
6. That would spawn a second LSP client and two processes would run

The reason this happen is because
1. We weren't awaiting the call to `restart`
2. While the dialogue was waiting for an answer, we hadn't set `this.client`. That means that invoking `stop` didn't create a stop promise, because the client wasn't set yet

The fix is to properly await the promises and set `this.client` early, so that we can properly return a `stop` promise when restarting a client that is hanging waiting for a dialogue confirmation.