### PR TITLE
Instantiate the client before performing bundler checks

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -126,6 +126,12 @@ export default class Client {
   }
 
   async start() {
+    this.client = new LanguageClient(
+      LSP_NAME,
+      this.serverOptions,
+      this.clientOptions
+    );
+
     if (
       (await this.statusItem.installGems()) ||
       (await this.statusItem.addMissingGem())
@@ -134,12 +140,6 @@ export default class Client {
     }
 
     await this.statusItem.updateStatus(ServerCommand.Start);
-
-    this.client = new LanguageClient(
-      LSP_NAME,
-      this.serverOptions,
-      this.clientOptions
-    );
 
     this.client.onTelemetry(this.telemetry.sendEvent.bind(this.telemetry));
     await this.client.start();


### PR DESCRIPTION
This change is from #369, but it was somehow lost when #320 was merged.