### PR TITLE
Await start, restart and stop commands

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -159,9 +159,15 @@ export default class Client {
 
   private registerCommands() {
     this.context.subscriptions.push(
-      vscode.commands.registerCommand("ruby-lsp.start", () => this.start()),
-      vscode.commands.registerCommand("ruby-lsp.restart", () => this.restart()),
-      vscode.commands.registerCommand("ruby-lsp.stop", () => this.stop())
+      vscode.commands.registerCommand("ruby-lsp.start", async () => {
+        await this.start();
+      }),
+      vscode.commands.registerCommand("ruby-lsp.restart", async () => {
+        await this.restart();
+      }),
+      vscode.commands.registerCommand("ruby-lsp.stop", async () => {
+        await this.stop();
+      })
     );
   }
 


### PR DESCRIPTION
A tiny improvement similar to #369. We should `await` for commands that start, restart or stop the server.