### PR TITLE
Delete GC tuning variables from the environment

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -222,6 +222,19 @@ export default class Client {
     const env = process.env;
     const useYjit = vscode.workspace.getConfiguration("rubyLsp").get("yjit");
 
+    [
+      "RUBY_GC_HEAP_OLDOBJECT_LIMIT_FACTOR",
+      "RUBY_GC_HEAP_FREE_SLOTS",
+      "RUBY_GC_HEAP_SLOTS_GROWTH_FACTOR",
+      "RUBY_GLOBAL_METHOD_CACHE_SIZE",
+      "RUBY_GC_MALLOC_LIMIT",
+      "RUBY_GC_HEAP_GROWTH_MAX_SLOTS",
+      "RUBY_GC_OLDMALLOC_LIMIT",
+      "RUBY_GC_HEAP_INIT_SLOTS",
+    ].forEach((key) => {
+      delete env[key];
+    });
+
     if (!this.ruby.rubyVersion) {
       return env;
     }


### PR DESCRIPTION
Sometimes developers may use Ruby's GC tuning environment variables to calibrate their application's performance. However, this is often not adequate for the Ruby LSP and usually results in spending an insane amount of time doing garbage collection.

There might be an opportunity to tune these specifically for the Ruby LSP to output better performance, but for the time being we should at least remove those and use defaults, which greatly improves performance where GC has been tuned.