### PR TITLE
Generalize how we remove Ruby GC variables

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -222,17 +222,10 @@ export default class Client {
     const env = process.env;
     const useYjit = vscode.workspace.getConfiguration("rubyLsp").get("yjit");
 
-    [
-      "RUBY_GC_HEAP_OLDOBJECT_LIMIT_FACTOR",
-      "RUBY_GC_HEAP_FREE_SLOTS",
-      "RUBY_GC_HEAP_SLOTS_GROWTH_FACTOR",
-      "RUBY_GLOBAL_METHOD_CACHE_SIZE",
-      "RUBY_GC_MALLOC_LIMIT",
-      "RUBY_GC_HEAP_GROWTH_MAX_SLOTS",
-      "RUBY_GC_OLDMALLOC_LIMIT",
-      "RUBY_GC_HEAP_INIT_SLOTS",
-    ].forEach((key) => {
-      delete env[key];
+    Object.keys(env).forEach((key) => {
+      if (key.startsWith("RUBY_GC")) {
+        delete env[key];
+      }
     });
 
     if (!this.ruby.rubyVersion) {


### PR DESCRIPTION
Closes #388

More GC tuning related variables will be added to Ruby 3.3, so we should generalize how we remove them.