### PR TITLE
Fix ZSH string interpolation issue

### DIFF
--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -63,7 +63,7 @@ export class Ruby {
   private async activate(ruby: string) {
     const result = await asyncExec(
       // eslint-disable-next-line no-process-env
-      `${process.env.SHELL} -lic '${ruby} --disable-gems -rjson -e "puts %Q{RUBY_ENV_ACTIVATE#{JSON.dump(ENV.to_h)}RUBY_ENV_ACTIVATE}"'`,
+      `${process.env.SHELL} -lic '${ruby} --disable-gems -rjson -e "printf %{RUBY_ENV_ACTIVATE%sRUBY_ENV_ACTIVATE}, JSON.dump(ENV.to_h)"'`,
       { cwd: this.workingFolder }
     );
 


### PR DESCRIPTION
The `#{}` string interpolation might cause the following issue.

```
Failed to activate chruby environment: Command failed: /bin/zsh -lic 'chruby-exec "ruby 3.0.2" -- ruby --disable-gems -rjson -e "puts %Q{RUBY_ENV_ACTIVATE#{JSON.dump(ENV.to_h)}RUBY_ENV_ACTIVATE}"'
(eval):1: can't change option: zle
zsh:1: no matches found: puts %Q{RUBY_ENV_ACTIVATE#{JSON.dump(ENV.to_h)}RUBY_ENV_ACTIVATE}
```