### PR TITLE
Allow restart command to fail gracefully

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -26,13 +26,13 @@ export default class Client {
   private telemetry: Telemetry;
   private ruby: Ruby;
   private statusItem: StatusItem;
+  private outputChannel = vscode.window.createOutputChannel(LSP_NAME);
 
   constructor(
     context: vscode.ExtensionContext,
     telemetry: Telemetry,
     ruby: Ruby
   ) {
-    const outputChannel = vscode.window.createOutputChannel(LSP_NAME);
     this.workingFolder = vscode.workspace.workspaceFolders![0].uri.fsPath;
     this.telemetry = telemetry;
     this.ruby = ruby;
@@ -56,7 +56,7 @@ export default class Client {
     this.clientOptions = {
       documentSelector: [{ scheme: "file", language: "ruby" }],
       diagnosticCollectionName: LSP_NAME,
-      outputChannel,
+      outputChannel: this.outputChannel,
       revealOutputChannelOn: RevealOutputChannelOn.Never,
       initializationOptions: {
         enabledFeatures: this.listOfEnabledFeatures(),
@@ -153,21 +153,24 @@ export default class Client {
   }
 
   async restart() {
-    await this.stop();
-    await this.start();
+    try {
+      await this.stop();
+      await this.start();
+    } catch (error: any) {
+      this.outputChannel.appendLine(
+        `Error restarting the server: ${error.message}`
+      );
+    }
   }
 
   private registerCommands() {
     this.context.subscriptions.push(
-      vscode.commands.registerCommand("ruby-lsp.start", async () => {
-        await this.start();
-      }),
-      vscode.commands.registerCommand("ruby-lsp.restart", async () => {
-        await this.restart();
-      }),
-      vscode.commands.registerCommand("ruby-lsp.stop", async () => {
-        await this.stop();
-      })
+      vscode.commands.registerCommand("ruby-lsp.start", this.start.bind(this)),
+      vscode.commands.registerCommand(
+        "ruby-lsp.restart",
+        this.restart.bind(this)
+      ),
+      vscode.commands.registerCommand("ruby-lsp.stop", this.stop.bind(this))
     );
   }
 
@@ -198,15 +201,9 @@ export default class Client {
     );
     this.context.subscriptions.push(watcher);
 
-    watcher.onDidChange(async () => {
-      await this.restart();
-    });
-    watcher.onDidCreate(async () => {
-      await this.restart();
-    });
-    watcher.onDidDelete(async () => {
-      await this.restart();
-    });
+    watcher.onDidChange(this.restart.bind(this));
+    watcher.onDidCreate(this.restart.bind(this));
+    watcher.onDidDelete(this.restart.bind(this));
   }
 
   private listOfEnabledFeatures(): string[] {


### PR DESCRIPTION
Closes Shopify/ruby-lsp#1483

If we let commands raise, VS Code won't let you use them again without reloading the window completely. That's not super helpful and we should rather catch the error and log it in the output channel.

Also, as accurately pointed out by Ufuk https://github.com/Shopify/vscode-ruby-lsp/pull/385#discussion_r1101846496, declaring a function as `async` and then only doing `await` inside of them has no difference when compared to just returning the function straight away. The behaviour will depend on whether the consumer of the function is awaiting or not (in this case VS Code). So I switched to a less verbose implementation.