### PR TITLE
Allow selecting version manager next to Ruby version

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,15 +25,15 @@
   "contributes": {
     "commands": [
       {
-        "command": "ruby-lsp.start",
+        "command": "rubyLsp.start",
         "title": "Ruby LSP: Start"
       },
       {
-        "command": "ruby-lsp.restart",
+        "command": "rubyLsp.restart",
         "title": "Ruby LSP: Restart"
       },
       {
-        "command": "ruby-lsp.stop",
+        "command": "rubyLsp.stop",
         "title": "Ruby LSP: Stop"
       }
     ],

--- a/src/client.ts
+++ b/src/client.ts
@@ -13,7 +13,7 @@ import {
 
 import { Telemetry } from "./telemetry";
 import { Ruby } from "./ruby";
-import { StatusItem, ServerCommand } from "./status";
+import { StatusItem, Command } from "./status";
 
 const LSP_NAME = "Ruby LSP";
 const asyncExec = promisify(exec);
@@ -150,7 +150,7 @@ export default class Client {
       this.clientOptions
     );
 
-    await this.statusItem.refresh(ServerCommand.Start, this.ruby);
+    await this.statusItem.refresh(Command.Start, this.ruby);
 
     this.client.onTelemetry((event) =>
       this.telemetry.sendEvent({
@@ -164,7 +164,7 @@ export default class Client {
 
   async stop(): Promise<void> {
     if (this.client) {
-      await this.statusItem.refresh(ServerCommand.Stop, this.ruby);
+      await this.statusItem.refresh(Command.Stop, this.ruby);
       return this.client.stop();
     }
   }
@@ -186,12 +186,9 @@ export default class Client {
 
   private registerCommands() {
     this.context.subscriptions.push(
-      vscode.commands.registerCommand("ruby-lsp.start", this.start.bind(this)),
-      vscode.commands.registerCommand(
-        "ruby-lsp.restart",
-        this.restart.bind(this)
-      ),
-      vscode.commands.registerCommand("ruby-lsp.stop", this.stop.bind(this))
+      vscode.commands.registerCommand(Command.Start, this.start.bind(this)),
+      vscode.commands.registerCommand(Command.Restart, this.restart.bind(this)),
+      vscode.commands.registerCommand(Command.Stop, this.stop.bind(this))
     );
   }
 

--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -6,12 +6,21 @@ import * as vscode from "vscode";
 
 const asyncExec = promisify(exec);
 
+export enum VersionManager {
+  Asdf = "asdf",
+  Chruby = "chruby",
+  Rbenv = "rbenv",
+  Rvm = "rvm",
+  Shadowenv = "shadowenv",
+  None = "none",
+}
+
 export class Ruby {
   public rubyVersion?: string;
   public yjitEnabled?: boolean;
   public supportsYjit?: boolean;
   private workingFolder: string;
-  private versionManager?: string;
+  private versionManager?: VersionManager;
 
   constructor() {
     this.workingFolder = vscode.workspace.workspaceFolders![0].uri.fsPath;
@@ -36,7 +45,7 @@ export class Ruby {
         case "rvm":
           await this.activate("rvm-auto-ruby");
           break;
-        case "none":
+        case VersionManager.None:
           break;
         default:
           await this.activateShadowenv();

--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -33,16 +33,16 @@ export class Ruby {
 
     try {
       switch (this.versionManager) {
-        case "asdf":
+        case VersionManager.Asdf:
           await this.activate("asdf exec ruby");
           break;
-        case "chruby":
+        case VersionManager.Chruby:
           await this.activateChruby();
           break;
-        case "rbenv":
+        case VersionManager.Rbenv:
           await this.activate("rbenv exec ruby");
           break;
-        case "rvm":
+        case VersionManager.Rvm:
           await this.activate("rvm-auto-ruby");
           break;
         case VersionManager.None:

--- a/src/status.ts
+++ b/src/status.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 
-import { Ruby } from "./ruby";
+import { Ruby, VersionManager } from "./ruby";
 
 export enum ServerCommand {
   Start = "ruby-lsp.start",
@@ -113,6 +113,10 @@ export class StatusItem {
       vscode.languages.createLanguageStatusItem("rubyVersion", this.selector);
     rubyVersion.name = "Ruby LSP Status";
     rubyVersion.text = `Using Ruby ${this.ruby.rubyVersion}`;
+    rubyVersion.command = {
+      title: "Change version manager",
+      command: "rubyLsp.selectRubyVersionManager",
+    };
 
     return rubyVersion;
   }
@@ -199,6 +203,22 @@ export class StatusItem {
           this.experimentalFeaturesStatus.text = message;
           this.experimentalFeaturesStatus.command!.title =
             experimentalFeaturesEnabled ? "Enable" : "Disable";
+        }
+      )
+    );
+
+    this.context.subscriptions.push(
+      vscode.commands.registerCommand(
+        "rubyLsp.selectRubyVersionManager",
+        async () => {
+          const options = Object.values(VersionManager);
+          const manager = await vscode.window.showQuickPick(options);
+
+          if (manager !== undefined) {
+            vscode.workspace
+              .getConfiguration("rubyLsp")
+              .update("rubyVersionManager", manager, true, true);
+          }
         }
       )
     );

--- a/src/status.ts
+++ b/src/status.ts
@@ -2,20 +2,25 @@ import * as vscode from "vscode";
 
 import { Ruby, VersionManager } from "./ruby";
 
-export enum ServerCommand {
-  Start = "ruby-lsp.start",
-  Stop = "ruby-lsp.stop",
-  Restart = "ruby-lsp.restart",
+// Lists every Command in the Ruby LSP
+export enum Command {
+  Start = "rubyLsp.start",
+  Stop = "rubyLsp.stop",
+  Restart = "rubyLsp.restart",
+  ToggleExperimentalFeatures = "rubyLsp.toggleExperimentalFeatures",
+  ServerOptions = "rubyLsp.serverOptions",
+  ToggleYjit = "rubyLsp.toggleYjit",
+  SelectVersionManager = "rubyLsp.selectRubyVersionManager",
 }
 
 const STOPPED_SERVER_OPTIONS = [
-  { label: "Ruby LSP: Start", description: "ruby-lsp.start" },
-  { label: "Ruby LSP: Restart", description: "ruby-lsp.restart" },
+  { label: "Ruby LSP: Start", description: Command.Start },
+  { label: "Ruby LSP: Restart", description: Command.Restart },
 ];
 
 const STARTED_SERVER_OPTIONS = [
-  { label: "Ruby LSP: Stop", description: "ruby-lsp.stop" },
-  { label: "Ruby LSP: Restart", description: "ruby-lsp.restart" },
+  { label: "Ruby LSP: Stop", description: Command.Stop },
+  { label: "Ruby LSP: Restart", description: Command.Restart },
 ];
 
 export class StatusItem {
@@ -43,7 +48,7 @@ export class StatusItem {
 
     this.serverStatus.command = {
       title: "Configure",
-      command: "rubyLsp.serverOptions",
+      command: Command.ServerOptions,
       arguments: [STARTED_SERVER_OPTIONS],
     };
 
@@ -58,24 +63,24 @@ export class StatusItem {
     this.registerCommands();
   }
 
-  public async refresh(status: ServerCommand, ruby: Ruby) {
+  public async refresh(status: Command, ruby: Ruby) {
     this.ruby = ruby;
     this.rubyVersionStatus.text = `Using Ruby ${this.ruby.rubyVersion}`;
     this.refreshYjitStatus();
     this.serverStatus.severity = vscode.LanguageStatusSeverity.Information;
 
     switch (status) {
-      case ServerCommand.Start: {
+      case Command.Start: {
         this.serverStatus.text = "Ruby LSP: Running...";
         this.serverStatus.command!.arguments = [STARTED_SERVER_OPTIONS];
         break;
       }
-      case ServerCommand.Stop: {
+      case Command.Stop: {
         this.serverStatus.text = "Ruby LSP: Stopped";
         this.serverStatus.command!.arguments = [STOPPED_SERVER_OPTIONS];
         break;
       }
-      case ServerCommand.Restart: {
+      case Command.Restart: {
         this.serverStatus.text = "Ruby LSP: Error";
         this.serverStatus.severity = vscode.LanguageStatusSeverity.Error;
         this.serverStatus.command!.arguments = [STOPPED_SERVER_OPTIONS];
@@ -94,7 +99,7 @@ export class StatusItem {
 
       this.yjitStatus.command = {
         title: "Disable",
-        command: "rubyLsp.toggleYjit",
+        command: Command.ToggleYjit,
       };
     } else {
       this.yjitStatus.text = "YJIT disabled";
@@ -102,7 +107,7 @@ export class StatusItem {
       if (this.ruby.supportsYjit) {
         this.yjitStatus.command = {
           title: "Enable",
-          command: "rubyLsp.toggleYjit",
+          command: Command.ToggleYjit,
         };
       }
     }
@@ -115,7 +120,7 @@ export class StatusItem {
     rubyVersion.text = `Using Ruby ${this.ruby.rubyVersion}`;
     rubyVersion.command = {
       title: "Change version manager",
-      command: "rubyLsp.selectRubyVersionManager",
+      command: Command.SelectVersionManager,
     };
 
     return rubyVersion;
@@ -152,7 +157,7 @@ export class StatusItem {
     status.text = message;
     status.command = {
       title: experimentalFeaturesEnabled ? "Disable" : "Enable",
-      command: "rubyLsp.toggleExperimentalFeatures",
+      command: Command.ToggleExperimentalFeatures,
     };
 
     return status;
@@ -160,7 +165,7 @@ export class StatusItem {
 
   private registerCommands() {
     this.context.subscriptions.push(
-      vscode.commands.registerCommand("rubyLsp.toggleYjit", async () => {
+      vscode.commands.registerCommand(Command.ToggleYjit, async () => {
         const lspConfig = vscode.workspace.getConfiguration("rubyLsp");
         const yjitEnabled = lspConfig.get("yjit");
         lspConfig.update("yjit", !yjitEnabled, true, true);
@@ -171,7 +176,7 @@ export class StatusItem {
 
     this.context.subscriptions.push(
       vscode.commands.registerCommand(
-        "rubyLsp.serverOptions",
+        Command.ServerOptions,
         async (options: [{ label: string; description: string }]) => {
           const result = await vscode.window.showQuickPick(options, {
             placeHolder: "Select server action",
@@ -185,7 +190,7 @@ export class StatusItem {
 
     this.context.subscriptions.push(
       vscode.commands.registerCommand(
-        "rubyLsp.toggleExperimentalFeatures",
+        Command.ToggleExperimentalFeatures,
         async () => {
           const lspConfig = vscode.workspace.getConfiguration("rubyLsp");
           const experimentalFeaturesEnabled = lspConfig.get(
@@ -209,7 +214,7 @@ export class StatusItem {
 
     this.context.subscriptions.push(
       vscode.commands.registerCommand(
-        "rubyLsp.selectRubyVersionManager",
+        Command.SelectVersionManager,
         async () => {
           const options = Object.values(VersionManager);
           const manager = await vscode.window.showQuickPick(options);


### PR DESCRIPTION
Closes #392

Allow selecting the Ruby version manager in the language status item.