### PR TITLE
Avoid mutating the environment with RUBYOPT

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ruby-lsp",
   "displayName": "Ruby LSP",
   "description": "VS Code plugin for connecting with the Ruby LSP",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "publisher": "Shopify",
   "repository": {
     "type": "git",

--- a/src/client.ts
+++ b/src/client.ts
@@ -227,7 +227,7 @@ export default class Client {
 
   private getEnv() {
     // eslint-disable-next-line no-process-env
-    const env = process.env;
+    const env = { ...process.env };
     const useYjit = vscode.workspace.getConfiguration("rubyLsp").get("yjit");
 
     Object.keys(env).forEach((key) => {


### PR DESCRIPTION
If we simply assign `env = process.env`, then when we change keys in `env` we're mutating `process.env` as well - which leaks across different extensions.

This means that we append `RUBYOPT=--yjit` in the process environment and it ends up applying to other extensions that spawn Ruby processes, which may lead to issues.

The fix is to simply create a clone of the environment, which we can do by destructuring it inside a new object.