### PR TITLE
Contribute default configurations to exclude .ruby-lsp folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,16 @@
         "title": "Ruby LSP: Stop"
       }
     ],
+    "configurationDefaults": {
+      "[ruby]": {
+        "files.exclude": {
+          "**/.ruby-lsp": true
+        },
+        "search.exclude": {
+          "**/.ruby-lsp": true
+        }
+      }
+    },
     "configuration": {
       "title": "Ruby LSP",
       "properties": {


### PR DESCRIPTION
To avoid having the custom Gemfile show up in searches and in the file tree, we can [contribute configuration defaults](https://code.visualstudio.com/api/references/contribution-points#contributes.configurationDefaults) that exclude the entire folder.