### PR TITLE
Fix setup when there's no Gemfile.lock

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -251,10 +251,12 @@ export default class Client {
     // Copy the current `Gemfile.lock` to the `.ruby-lsp` directory to make sure we're using the right versions of
     // RuboCop and related extensions. Because we do this in every initialization, we always use the latest version of
     // the Ruby LSP
-    fs.cpSync(
-      path.join(this.workingFolder, "Gemfile.lock"),
-      path.join(this.workingFolder, ".ruby-lsp", "Gemfile.lock")
-    );
+    if (fs.existsSync(path.join(this.workingFolder, "Gemfile.lock"))) {
+      fs.cpSync(
+        path.join(this.workingFolder, "Gemfile.lock"),
+        path.join(this.workingFolder, ".ruby-lsp", "Gemfile.lock")
+      );
+    }
 
     await asyncExec(`BUNDLE_GEMFILE=${customGemfilePath} bundle install`, {
       cwd: this.workingFolder,


### PR DESCRIPTION
If there's no `Gemfile`, then there will also not be a `Gemfile.lock`. To allow the Ruby LSP to work with scripts and such, then we need to avoid trying to copy the `Gemfile.lock` if it's not there.