### PR TITLE
Refactor status items into separate classes

### DIFF
--- a/src/test/suite/status.test.ts
+++ b/src/test/suite/status.test.ts
@@ -1,0 +1,183 @@
+import * as assert from "assert";
+
+import * as vscode from "vscode";
+import { beforeEach, afterEach } from "mocha";
+
+import { Ruby } from "../../ruby";
+import {
+  RubyVersionStatus,
+  ServerStatus,
+  ExperimentalFeaturesStatus,
+  Command,
+  YjitStatus,
+  StatusItem,
+  ServerState,
+  ClientInterface,
+} from "../../status";
+
+suite("StatusItems", () => {
+  let ruby: Ruby;
+  let context: vscode.ExtensionContext;
+  let status: StatusItem;
+  let client: ClientInterface;
+
+  beforeEach(() => {
+    context = { subscriptions: [] } as unknown as vscode.ExtensionContext;
+  });
+
+  afterEach(() => {
+    context.subscriptions.forEach((subscription) => {
+      subscription.dispose();
+    });
+    status.dispose();
+  });
+
+  suite("RubyVersionStatus", () => {
+    beforeEach(() => {
+      ruby = { rubyVersion: "3.2.0" } as Ruby;
+      client = {
+        context,
+        ruby,
+        state: ServerState.Running,
+      };
+      status = new RubyVersionStatus(client);
+    });
+
+    test("Status is initialized with the right values", async () => {
+      assert.strictEqual(status.item.text, "Using Ruby 3.2.0");
+      assert.strictEqual(status.item.name, "Ruby LSP Status");
+      assert.strictEqual(status.item.command?.title, "Change version manager");
+      assert.strictEqual(
+        status.item.command?.command,
+        Command.SelectVersionManager
+      );
+      assert.strictEqual(context.subscriptions.length, 1);
+    });
+
+    test("Refresh updates version string", async () => {
+      assert.strictEqual(status.item.text, "Using Ruby 3.2.0");
+
+      client.ruby.rubyVersion = "3.2.1";
+      status.refresh();
+      assert.strictEqual(status.item.text, "Using Ruby 3.2.1");
+    });
+  });
+
+  suite("ServerStatus", () => {
+    beforeEach(() => {
+      ruby = {} as Ruby;
+      client = { context, ruby, state: ServerState.Running };
+      status = new ServerStatus(client);
+    });
+
+    test("Status is initialized with the right values", async () => {
+      assert.strictEqual(status.item.text, "Ruby LSP: Starting");
+      assert.strictEqual(status.item.name, "Ruby LSP Status");
+      assert.strictEqual(
+        status.item.severity,
+        vscode.LanguageStatusSeverity.Information
+      );
+      assert.strictEqual(status.item.command?.title, "Configure");
+      assert.strictEqual(status.item.command?.command, Command.ServerOptions);
+      assert.strictEqual(context.subscriptions.length, 1);
+    });
+
+    test("Refresh when server is starting", async () => {
+      client.state = ServerState.Starting;
+      status.refresh();
+      assert.strictEqual(status.item.text, "Ruby LSP: Starting");
+      assert.strictEqual(
+        status.item.severity,
+        vscode.LanguageStatusSeverity.Information
+      );
+    });
+
+    test("Refresh when server is stopping", async () => {
+      client.state = ServerState.Stopped;
+      status.refresh();
+      assert.strictEqual(status.item.text, "Ruby LSP: Stopped");
+      assert.strictEqual(
+        status.item.severity,
+        vscode.LanguageStatusSeverity.Information
+      );
+    });
+
+    test("Refresh when server has errored", async () => {
+      client.state = ServerState.Error;
+      status.refresh();
+      assert.strictEqual(status.item.text, "Ruby LSP: Error");
+      assert.strictEqual(
+        status.item.severity,
+        vscode.LanguageStatusSeverity.Error
+      );
+    });
+  });
+
+  suite("ExperimentalFeaturesStatus", () => {
+    beforeEach(() => {
+      ruby = {} as Ruby;
+      client = {
+        context,
+        ruby,
+        state: ServerState.Running,
+      };
+      status = new ExperimentalFeaturesStatus(client);
+    });
+
+    test("Status is initialized with the right values", async () => {
+      assert.strictEqual(status.item.text, "Experimental features disabled");
+      assert.strictEqual(status.item.name, "Experimental features");
+      assert.strictEqual(status.item.command?.title, "Enable");
+      assert.strictEqual(
+        status.item.command?.command,
+        Command.ToggleExperimentalFeatures
+      );
+      assert.strictEqual(context.subscriptions.length, 1);
+    });
+  });
+
+  suite("YjitStatus when Ruby supports it", () => {
+    beforeEach(() => {
+      ruby = { supportsYjit: true } as Ruby;
+      client = { context, ruby, state: ServerState.Running };
+      status = new YjitStatus(client);
+    });
+
+    test("Status is initialized with the right values", async () => {
+      assert.strictEqual(status.item.text, "YJIT enabled");
+      assert.strictEqual(status.item.name, "YJIT");
+      assert.strictEqual(status.item.command?.title, "Disable");
+      assert.strictEqual(status.item.command?.command, Command.ToggleYjit);
+      assert.strictEqual(context.subscriptions.length, 1);
+    });
+
+    test("Refresh updates whether it's disabled or enabled", async () => {
+      assert.strictEqual(status.item.text, "YJIT enabled");
+
+      client.ruby.supportsYjit = false;
+      status.refresh();
+      assert.strictEqual(status.item.text, "YJIT disabled");
+    });
+  });
+
+  suite("YjitStatus when Ruby does not support it", () => {
+    beforeEach(() => {
+      ruby = { supportsYjit: false } as Ruby;
+      client = { context, ruby, state: ServerState.Running };
+      status = new YjitStatus(client);
+    });
+
+    test("Refresh ignores YJIT configuration if Ruby doesn't support it", async () => {
+      assert.strictEqual(status.item.text, "YJIT disabled");
+      assert.strictEqual(status.item.command, undefined);
+
+      const lspConfig = vscode.workspace.getConfiguration("rubyLsp");
+      lspConfig.update("yjit", true, true, true);
+      client.ruby.supportsYjit = false;
+      status.refresh();
+
+      assert.strictEqual(status.item.text, "YJIT disabled");
+      assert.strictEqual(status.item.command, undefined);
+    });
+  });
+});


### PR DESCRIPTION
This is a suggestion refactor on our status items. While working on Shopify/ruby-lsp#1542, I noticed the `Status` class is getting more and more complex and it's difficult to see what's related to a single item.

This PR
- Refactors all status items as separate classes that all inherit from `Status`. They are all initialized through their constructors, implement a `registerCommand` function in case they need to register and implement a `refresh` method in case their information changes on a restart
- Adds tests for all different status item classes

### Drawbacks

The weird thing about this approach is that `refresh` will always need to accept objects required to update the items - even if some of them don't require the same objects. For example, `status` is only pertinent to `ServerStatus`, but all of them receive it as an argument.

Still I think it's significantly easier to go over which statuses exist.