### PR TITLE
Move environment manipulation completely to the Ruby object

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,13 +7,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-      - name: Build
-        uses: actions/setup-node@v2
+      - name: Set up Node
+        uses: actions/setup-node@v3
         with:
           node-version: "17"
           cache: "yarn"
+
+      # We need some Ruby installed for the environment activation tests
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: "3.2"
 
       - name: 📦 Install dependencies
         run: yarn --frozen-lockfile

--- a/src/client.ts
+++ b/src/client.ts
@@ -136,15 +136,12 @@ export default class Client implements ClientInterface {
       }
     );
 
-    // We need to get the environment again every time we start in case the user changed the environment manager
-    const env = this.getEnv();
-
     const executable: Executable = {
       command: "bundle",
       args: ["exec", "ruby-lsp"],
       options: {
         cwd: this.workingFolder,
-        env,
+        env: this.ruby.env,
       },
     };
 
@@ -329,49 +326,6 @@ export default class Client implements ClientInterface {
     }
 
     return allFeatures.filter((key) => features[key]);
-  }
-
-  private getEnv() {
-    // eslint-disable-next-line no-process-env
-    const env = { ...process.env };
-    const useYjit = vscode.workspace.getConfiguration("rubyLsp").get("yjit");
-
-    Object.keys(env).forEach((key) => {
-      if (key.startsWith("RUBY_GC")) {
-        delete env[key];
-      }
-    });
-
-    // Use our custom Gemfile to allow RuboCop and extensions to work without having to add ruby-lsp to the bundle. Note
-    // that we can't do this for the ruby-lsp repository itself otherwise the gem is activated twice
-    if (!this.workingFolder.endsWith("ruby-lsp")) {
-      env.BUNDLE_GEMFILE = path.join(
-        this.workingFolder,
-        ".ruby-lsp",
-        "Gemfile"
-      );
-    }
-
-    if (!this._ruby.rubyVersion) {
-      return env;
-    }
-
-    // Enabling YJIT only provides a performance benefit on Ruby 3.2.0 and above
-    const yjitEnabled = useYjit && this._ruby.supportsYjit;
-
-    if (!yjitEnabled) {
-      return env;
-    }
-
-    // RUBYOPT may be empty or it may contain bundler paths. In the second case, we must concat to avoid accidentally
-    // removing the paths from the env variable
-    if (env.RUBYOPT) {
-      env.RUBYOPT.concat(" --yjit");
-    } else {
-      env.RUBYOPT = "--yjit";
-    }
-
-    return env;
   }
 
   // Leave this function for a while to assist users migrating from the old version of the extension

--- a/src/test/suite/ruby.test.ts
+++ b/src/test/suite/ruby.test.ts
@@ -1,0 +1,59 @@
+import * as assert from "assert";
+
+import { before, after } from "mocha";
+import * as vscode from "vscode";
+
+import { Ruby } from "../../ruby";
+
+suite("Ruby environment activation", () => {
+  let ruby: Ruby;
+  const configuration = vscode.workspace.getConfiguration("rubyLsp");
+  const currentManager = configuration.get("rubyVersionManager")!;
+
+  before(async () => {
+    await configuration.update("rubyVersionManager", "none", true, true);
+  });
+
+  after(async () => {
+    await configuration.update(
+      "rubyVersionManager",
+      currentManager,
+      true,
+      true
+    );
+  });
+
+  test("Activate fetches Ruby information when outside of Ruby LSP", async () => {
+    ruby = new Ruby("fake/some/project");
+    await ruby.activateRuby();
+
+    assert.ok(ruby.rubyVersion, "Expected Ruby version to be set");
+    assert.strictEqual(
+      ruby.supportsYjit,
+      true,
+      "Expected YJIT support to be enabled"
+    );
+    assert.strictEqual(
+      ruby.env.BUNDLE_GEMFILE,
+      "fake/some/project/.ruby-lsp/Gemfile",
+      "Expected BUNDLE_GEMFILE to be set"
+    );
+  });
+
+  test("Activate fetches Ruby information when working on the Ruby LSP", async () => {
+    ruby = new Ruby("/fake/ruby-lsp");
+    await ruby.activateRuby();
+
+    assert.ok(ruby.rubyVersion, "Expected Ruby version to be set");
+    assert.strictEqual(
+      ruby.supportsYjit,
+      true,
+      "Expected YJIT support to be enabled"
+    );
+    assert.strictEqual(
+      ruby.env.BUNDLE_GEMFILE,
+      undefined,
+      "Expected BUNDLE_GEMFILE to not be set for the ruby-lsp folder"
+    );
+  });
+});


### PR DESCRIPTION
The issue in #429 got me thinking about how we also mutate the environment during activation and if we manipulating it in the client made sense.

I think all environment manipulation should be contained in the `Ruby` class - since we're interested in the Ruby environment after all. This PR
- moves all env related behaviour inside `Ruby`
- stops mutating `process.env` completely
- adds a few tests, limited to what we can verify without a version manager installed
- adds setup-ruby to CI, since we need some Ruby to be installed in order to check for the information