### PR TITLE
Allow marking features as experimental

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -49,6 +49,9 @@ export default class Client implements ClientInterface {
       revealOutputChannelOn: RevealOutputChannelOn.Never,
       initializationOptions: {
         enabledFeatures: this.listOfEnabledFeatures(),
+        experimentalFeaturesEnabled: vscode.workspace
+          .getConfiguration("rubyLsp")
+          .get("enableExperimentalFeatures"),
       },
       middleware: {
         provideOnTypeFormattingEdits: async (
@@ -321,14 +324,8 @@ export default class Client implements ClientInterface {
   private listOfEnabledFeatures(): string[] {
     const configuration = vscode.workspace.getConfiguration("rubyLsp");
     const features: EnabledFeatures = configuration.get("enabledFeatures")!;
-    const allFeatures = Object.keys(features);
 
-    // If enableExperimentalFeatures is true, all features are enabled
-    if (configuration.get("enableExperimentalFeatures")) {
-      return allFeatures;
-    }
-
-    return allFeatures.filter((key) => features[key]);
+    return Object.keys(features).filter((key) => features[key]);
   }
 
   private getEnv() {


### PR DESCRIPTION
Closes #399

Currently, if experimental features are enabled, we're just enabling everything. That behaviour is not very accurate and probably surprising. We need a way of marking features as experimental so that only those are enabled by the setting.

Additionally, it's the server that should decide whether a feature is experimental or not - otherwise they could be accidentally enabled by other editors.

This PR switches our mechanism to just send whether experimental features are enabled or not to the server. When returning capabilities, the server can then read this and determine if it wants to broadcast experimental feature capabilities or not.

Note: we don't have any experimental features at this time, so there's no PR in the server to accompany this one.