### PR TITLE
Create a debug executable for running the server with debugger

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -53,13 +53,21 @@ export default class Client implements ClientInterface {
 
     await this.setupCustomGemfile();
 
+    const executableOptions = {
+      cwd: this.workingFolder,
+      env: this.ruby.env,
+    };
+
     const executable: Executable = {
       command: "bundle",
       args: ["exec", "ruby-lsp"],
-      options: {
-        cwd: this.workingFolder,
-        env: this.ruby.env,
-      },
+      options: executableOptions,
+    };
+
+    const debugExecutable: Executable = {
+      command: "bundle",
+      args: ["exec", "ruby-lsp", "--debug"],
+      options: executableOptions,
     };
 
     const configuration = vscode.workspace.getConfiguration("rubyLsp");
@@ -135,7 +143,7 @@ export default class Client implements ClientInterface {
 
     this.client = new LanguageClient(
       LSP_NAME,
-      { run: executable, debug: executable },
+      { run: executable, debug: debugExecutable },
       clientOptions
     );
 


### PR DESCRIPTION
This allows us to run `ruby-lsp` with `ruby/debug` and be available to be attached through console or VS Code (this is currently blocked by https://github.com/ruby/vscode-rdbg/pull/113 though).

### Debugging a running Ruby LSP process in console

1. [In `vscode-ruby-lsp`] Run the extension in debug mode
2. [In `ruby-lsp`] run `bin/rdbg -A` (needs https://github.com/Shopify/ruby-lsp/pull/557)
3. [In `ruby-lsp`] Upon connection, it'd open up the debugger console. Type `b Class#method` or `b file:line` to set a breakpoint(s)
4. [In `ruby-lsp`] Type `c` to continue the LSP
5. [In the `Extension Development Host`] Trigger the request that'll hit the breakpoint

Note: adding `binding.*` in `ruby-lsp` won't work because that's not the version that'd be picked up by the extension.

Questions:

- Should the above debugging steps be documented in `ruby-lsp` or this repo's readme 🤔 
- Should we and how to let `vscode-ruby-lsp` pick up a local version of `ruby-lsp`?