### PR TITLE
Use the core `chruby` script for activation

### DIFF
--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -90,7 +90,7 @@ export class Ruby {
 
   private async activateChruby() {
     const rubyVersion = await this.readRubyVersion();
-    await this.activate(`chruby-exec "${rubyVersion}" -- ruby`);
+    await this.activate(`chruby "${rubyVersion}" && ruby`);
   }
 
   private async activate(ruby: string) {


### PR DESCRIPTION
I noticed that not all installations of `chruby` have to have the `chruby-exec` script installed (for example, our dev machines at Shopify have the core `chruby` script but not `chruby-exec`).

Since `chruby-exec` is basically a shorthand for running: [`chruby VERSION && SUBCOMMAND`][0], I think it's safe to replicate that behaviour so that we can rely only on the core `chruby` script.

This also means that we save on the `chruby-exec` creating yet another subshell to do its work.

[0]: https://github.com/postmodern/chruby/blob/master/bin/chruby-exec#L43