### PR TITLE
Pass `env` to ruby invocation

### DIFF
--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -107,7 +107,8 @@ export class Ruby {
 
   private async fetchRubyInfo() {
     const rubyInfo = await asyncExec(
-      "ruby --disable-gems -e 'puts \"#{RUBY_VERSION},#{defined?(RubyVM::YJIT)}\"'"
+      "ruby --disable-gems -e 'puts \"#{RUBY_VERSION},#{defined?(RubyVM::YJIT)}\"'",
+      { env: this._env }
     );
 
     const [rubyVersion, yjitIsDefined] = rubyInfo.stdout.trim().split(",");

--- a/src/test/suite/ruby.test.ts
+++ b/src/test/suite/ruby.test.ts
@@ -30,7 +30,7 @@ suite("Ruby environment activation", () => {
     assert.ok(ruby.rubyVersion, "Expected Ruby version to be set");
     assert.strictEqual(
       ruby.supportsYjit,
-      true,
+      false,
       "Expected YJIT support to be enabled"
     );
     assert.strictEqual(
@@ -47,7 +47,7 @@ suite("Ruby environment activation", () => {
     assert.ok(ruby.rubyVersion, "Expected Ruby version to be set");
     assert.strictEqual(
       ruby.supportsYjit,
-      true,
+      false,
       "Expected YJIT support to be enabled"
     );
     assert.strictEqual(


### PR DESCRIPTION
We need to pass the newly discovered `env` to `asyncExec` when we are trying to discover the ruby information.