### PR TITLE
Update to Node 18.15.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Node
         uses: actions/setup-node@v3
         with:
-          node-version: "17"
+          node-version: "18"
           cache: "yarn"
 
       # We need some Ruby installed for the environment activation tests

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,9 +13,9 @@ jobs:
         name: Checkout
 
       - uses: actions/setup-node@v3
-        name: Use Node.js 17.x
+        name: Use Node.js 18.x
         with:
-          node-version: "17"
+          node-version: "18"
           cache: "yarn"
 
       - name: 📦 Install dependencies

--- a/dev.yml
+++ b/dev.yml
@@ -5,7 +5,7 @@ type: nodejs
 up:
   - node:
       yarn: true
-      version: 17.5.0
+      version: 18.15.0
 
 commands:
   package: "yarn run package"


### PR DESCRIPTION
We can't get CI to pass on #456 because of Node 17. This PR just upgrades to Node 18.