### PR TITLE
Fail gracefully on ruby activation errors

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -48,6 +48,12 @@ export default class Client implements ClientInterface {
   }
 
   async start() {
+    if (this._ruby.error) {
+      this._state = ServerState.Error;
+      this.statusItems.refresh();
+      return;
+    }
+
     this._state = ServerState.Starting;
     this.statusItems.refresh();
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,7 +13,6 @@ export async function activate(context: vscode.ExtensionContext) {
   const telemetry = new Telemetry(context);
   client = new Client(context, telemetry, ruby);
 
-  // Adding this delay guarantees that the Ruby environment is activated before trying to start the server
   await client.start();
 }
 

--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -26,6 +26,7 @@ export class Ruby {
   // eslint-disable-next-line no-process-env
   private shell = process.env.SHELL;
   private _env: NodeJS.ProcessEnv = {};
+  private _error = false;
 
   constructor(
     workingFolder = vscode.workspace.workspaceFolders![0].uri.fsPath
@@ -35,6 +36,10 @@ export class Ruby {
 
   get env() {
     return this._env;
+  }
+
+  get error() {
+    return this._error;
   }
 
   async activateRuby() {
@@ -71,7 +76,10 @@ export class Ruby {
       await this.fetchRubyInfo();
       this.deleteGcEnvironmentVariables();
       this.setupBundlePath();
+      this._error = false;
     } catch (error: any) {
+      this._error = true;
+
       await vscode.window.showErrorMessage(
         `Failed to activate ${this.versionManager} environment: ${error.message}`
       );

--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -65,9 +65,6 @@ export class Ruby {
           break;
         default:
           await this.activateShadowenv();
-          await this.delay(500);
-          // eslint-disable-next-line no-process-env
-          this._env = { ...process.env };
           break;
       }
 
@@ -82,9 +79,27 @@ export class Ruby {
   }
 
   private async activateShadowenv() {
-    await vscode.extensions
-      .getExtension("shopify.vscode-shadowenv")
-      ?.activate();
+    const extension = vscode.extensions.getExtension(
+      "shopify.vscode-shadowenv"
+    );
+
+    if (!extension) {
+      throw new Error(
+        "The Ruby LSP version manager is configured to be shadowenv, but the shadowenv extension is not installed"
+      );
+    }
+
+    if (!fs.existsSync(path.join(this.workingFolder, ".shadowenv.d"))) {
+      throw new Error(
+        "The Ruby LSP version manager is configured to be shadowenv, \
+        but no .shadowenv.d directory was found in the workspace"
+      );
+    }
+
+    await extension.activate();
+    await this.delay(500);
+    // eslint-disable-next-line no-process-env
+    this._env = { ...process.env };
   }
 
   private async activateChruby() {

--- a/src/status.ts
+++ b/src/status.ts
@@ -64,16 +64,29 @@ export abstract class StatusItem {
 export class RubyVersionStatus extends StatusItem {
   constructor(client: ClientInterface) {
     super("rubyVersion", client);
-    this.item.text = `Using Ruby ${client.ruby.rubyVersion}`;
     this.item.name = "Ruby LSP Status";
     this.item.command = {
       title: "Change version manager",
       command: Command.SelectVersionManager,
     };
+
+    if (client.ruby.error) {
+      this.item.text = "Failed to activate Ruby";
+      this.item.severity = vscode.LanguageStatusSeverity.Error;
+    } else {
+      this.item.text = `Using Ruby ${client.ruby.rubyVersion}`;
+      this.item.severity = vscode.LanguageStatusSeverity.Information;
+    }
   }
 
   refresh(): void {
-    this.item.text = `Using Ruby ${this.client.ruby.rubyVersion}`;
+    if (this.client.ruby.error) {
+      this.item.text = "Failed to activate Ruby";
+      this.item.severity = vscode.LanguageStatusSeverity.Error;
+    } else {
+      this.item.text = `Using Ruby ${this.client.ruby.rubyVersion}`;
+      this.item.severity = vscode.LanguageStatusSeverity.Information;
+    }
   }
 
   registerCommand(): void {


### PR DESCRIPTION
Currently, if we fail to activate the Ruby environment, we rescue that error, display a message to the user and then proceed to try to boot the server - which results in a bunch of error dialogues spamming the user.

We shouldn't try to boot the server if we couldn't activate the Ruby environment. This PR
- Makes shadowenv activation a bit more robust. We can't try to activate if the extension is not present or if `.shadowenv.d` doesn't exist
- Prevents the server from starting if activation errored and updates the status items to reflect that