### PR TITLE
Fix infinite recursion detecting ruby version if no file exists

### DIFF
--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -156,21 +156,26 @@ export class Ruby {
     let dir = this.workingFolder;
 
     while (fs.existsSync(dir)) {
-      const versionFile = `${dir}/.ruby-version`;
-      dir = path.dirname(dir);
+      const versionFile = path.join(dir, ".ruby-version");
 
-      if (!fs.existsSync(versionFile)) {
-        continue;
+      if (fs.existsSync(versionFile)) {
+        const version = fs.readFileSync(versionFile, "utf8");
+        const trimmedVersion = version.trim();
+
+        if (trimmedVersion !== "") {
+          return trimmedVersion;
+        }
       }
 
-      const version = fs.readFileSync(versionFile, "utf8");
-      const trimmedVersion = version.trim();
+      const parent = path.dirname(dir);
 
-      if (trimmedVersion === "") {
-        continue;
+      // When we hit the root path (e.g. /), parent will be the same as dir.
+      // We don't want to loop forever in this case, so we break out of the loop.
+      if (parent === dir) {
+        break;
       }
 
-      return trimmedVersion;
+      dir = parent;
     }
 
     throw new Error("No .ruby-version file was found");


### PR DESCRIPTION
We need to be careful about the base case of the directory parent walk, since the root of the directory tree will have itself as its parent directory (e.g. on *nix systems `"/" === path.dirname("/")`). This causes us to enter an infinite loop while detecting the ruby version file, if no such file exists anywhere in the directory parents.

The fix is to check for that situation, and break the loop early. I also changed the loop logic a little so that we can do the parent directory look up at the end of the loop.