### PR TITLE
Add `Bundler` editor view

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   ],
   "activationEvents": [
     "onLanguage:ruby",
-    "workspaceContains:Gemfile.lock"
+    "workspaceContains:Gemfile.lock",
+    "onView:bundler"
   ],
   "main": "./out/extension.js",
   "contributes": {
@@ -39,6 +40,11 @@
       {
         "command": "rubyLsp.update",
         "title": "Ruby LSP: Update language server gem"
+      },
+      {
+        "command": "bundler.remove",
+        "title": "Remove Gem",
+        "icon": "$(trash)"
       }
     ],
     "configuration": {
@@ -224,7 +230,24 @@
         ],
         "configuration": "./languages/erb.json"
       }
-    ]
+    ],
+    "views": {
+      "explorer": [
+        {
+          "id": "bundler",
+          "name": "Bundler"
+        }
+      ]
+    },
+    "menus": {
+      "view/item/context": [
+        {
+          "command": "bundler.remove",
+          "when": "view == bundler && viewItem == gem",
+          "group": "inline"
+        }
+      ]
+    }
   },
   "scripts": {
     "vscode:prepublish": "yarn run esbuild-base --minify",

--- a/src/bundler.ts
+++ b/src/bundler.ts
@@ -1,0 +1,136 @@
+import * as vscode from "vscode";
+
+import { Ruby } from "./ruby";
+
+type GemPath = GemDirectoryPath | GemFilePath;
+type BundlerNode = Gem | GemPath;
+
+export class Bundler implements vscode.TreeDataProvider<BundlerNode> {
+  private _onDidChangeTreeData: vscode.EventEmitter<any> =
+    new vscode.EventEmitter<any>();
+
+  // eslint-disable-next-line @typescript-eslint/member-ordering
+  readonly onDidChangeTreeData: vscode.Event<any> =
+    this._onDidChangeTreeData.event;
+
+  constructor(private context: vscode.ExtensionContext, private ruby: Ruby) {
+    this.ruby = ruby;
+    this.context.subscriptions.push(
+      vscode.window.createTreeView("bundler", { treeDataProvider: this }),
+      vscode.commands.registerCommand("bundler.remove", (gem) =>
+        this.removeGem(gem)
+      )
+    );
+  }
+
+  getTreeItem(
+    element: BundlerNode
+  ): vscode.TreeItem | Thenable<vscode.TreeItem> {
+    return element;
+  }
+
+  getChildren(
+    element?: BundlerNode | undefined
+  ): vscode.ProviderResult<BundlerNode[]> {
+    if (element) {
+      return this.fetchGemEntries(element);
+    } else {
+      return this.fetchDependencies();
+    }
+  }
+
+  refresh(): void {
+    this._onDidChangeTreeData.fire(undefined);
+  }
+
+  private async fetchGemEntries(element: BundlerNode): Promise<GemPath[]> {
+    const dir = element.resourceUri;
+    const entries = await vscode.workspace.fs.readDirectory(dir);
+
+    return entries.map(([name, type]) => {
+      if (type === vscode.FileType.Directory) {
+        return new GemDirectoryPath(vscode.Uri.joinPath(dir, name));
+      } else {
+        return new GemFilePath(vscode.Uri.joinPath(dir, name));
+      }
+    });
+  }
+
+  private async runBundleCommand(command: string) {
+    return (
+      await this.ruby.run(`bundle ${command}`, { withOriginalGemfile: true })
+    )?.stdout;
+  }
+
+  private async fetchDependencies(): Promise<Gem[]> {
+    const versionList = await this.runBundleCommand("list");
+
+    if (!versionList) {
+      return [];
+    }
+
+    const pathList = (await this.runBundleCommand("list --paths"))?.split("\n");
+
+    if (!pathList) {
+      return [];
+    }
+
+    return Array.from(versionList.matchAll(/ {2}\* ([^(]+) \(([^)]+)\)/g)).map(
+      ([_, name, version], idx) => {
+        return new Gem(name, version, vscode.Uri.file(pathList[idx]));
+      }
+    );
+  }
+
+  private async removeGem(gem: Gem): Promise<void> {
+    const result = await vscode.window.showWarningMessage(
+      `Are you sure you want to remove the gem '${gem.name}' from the Gemfile?`,
+      { title: "Yes" },
+      { title: "No", isCloseAffordance: true }
+    );
+
+    if (result?.title === "Yes") {
+      await this.runBundleCommand(`remove ${gem.name}`);
+      this.refresh();
+    }
+  }
+}
+
+class Gem extends vscode.TreeItem {
+  constructor(
+    public readonly name: string,
+    public readonly version: string,
+    public readonly resourceUri: vscode.Uri
+  ) {
+    super(`${name} (${version})`, vscode.TreeItemCollapsibleState.Collapsed);
+    this.contextValue = "gem";
+    this.iconPath = new vscode.ThemeIcon("ruby");
+  }
+}
+
+class GemDirectoryPath extends vscode.TreeItem {
+  constructor(public readonly resourceUri: vscode.Uri) {
+    super(resourceUri, vscode.TreeItemCollapsibleState.Collapsed);
+    this.contextValue = "gem-directory-path";
+    this.description = true;
+
+    this.command = {
+      command: "list.toggleExpand",
+      title: "Toggle",
+    };
+  }
+}
+
+class GemFilePath extends vscode.TreeItem {
+  constructor(public readonly resourceUri: vscode.Uri) {
+    super(resourceUri, vscode.TreeItemCollapsibleState.None);
+    this.contextValue = "gem-file-path";
+    this.description = true;
+
+    this.command = {
+      command: "vscode.open",
+      title: "Open",
+      arguments: [resourceUri],
+    };
+  }
+}

--- a/src/client.ts
+++ b/src/client.ts
@@ -15,6 +15,7 @@ import {
 import { Telemetry } from "./telemetry";
 import { Ruby } from "./ruby";
 import { StatusItems, Command, ServerState, ClientInterface } from "./status";
+import { Bundler } from "./bundler";
 
 const LSP_NAME = "Ruby LSP";
 const asyncExec = promisify(exec);
@@ -30,6 +31,7 @@ export default class Client implements ClientInterface {
   private telemetry: Telemetry;
   private statusItems: StatusItems;
   private outputChannel = vscode.window.createOutputChannel(LSP_NAME);
+  private bundler: Bundler | undefined;
   #context: vscode.ExtensionContext;
   #ruby: Ruby;
   #state: ServerState = ServerState.Starting;
@@ -69,6 +71,8 @@ export default class Client implements ClientInterface {
 
       return;
     }
+
+    this.updateBundler();
 
     const executableOptions = {
       cwd: this.workingFolder,
@@ -237,6 +241,14 @@ export default class Client implements ClientInterface {
         this.updateServer.bind(this)
       )
     );
+  }
+
+  private updateBundler() {
+    if (this.bundler) {
+      this.bundler.refresh();
+    } else {
+      this.bundler = new Bundler(this.context, this.ruby);
+    }
   }
 
   private async setupCustomGemfile() {

--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -86,6 +86,18 @@ export class Ruby {
     }
   }
 
+  async run(command: string, options?: { withOriginalGemfile: boolean }) {
+    if (this._error) {
+      return;
+    }
+
+    const env = { ...this._env };
+    if (options?.withOriginalGemfile) {
+      env.BUNDLE_GEMFILE = path.join(this.workingFolder, "Gemfile");
+    }
+    return asyncExec(command, { env });
+  }
+
   private async activateShadowenv() {
     const extension = vscode.extensions.getExtension(
       "shopify.vscode-shadowenv"


### PR DESCRIPTION
This PR adds a `BUNDLER` view to the `Editor` sidebar view, which shows the gem dependencies of a Ruby project and allows users to browse the contents of those dependencies without leaving their current editor.

![Screenshot 2023-03-20 at 23 40 05](https://user-images.githubusercontent.com/224488/226471906-91dae039-17f7-41ce-9c7d-9582e2909044.png)


Here is what it looks like in action on the [Tapioca](https://github.com/Shopify/tapioca) repo:

https://user-images.githubusercontent.com/224488/226471740-2979d6f2-264b-4061-b86d-104aac0c5376.mov

This initial implementation builds most of the functionality on the client-side by executing `bundler` commands. I have plans to extract the functionality into a data model that would be returned from the Ruby LSP server via a custom LSP request. However, for the basic functionality, the current implementation works just fine.
