### PR TITLE
Show current manager when configuring

### DIFF
--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -22,7 +22,7 @@ export class Ruby {
   public yjitEnabled?: boolean;
   public supportsYjit?: boolean;
   private workingFolder: string;
-  private versionManager?: VersionManager;
+  #versionManager?: VersionManager;
   // eslint-disable-next-line no-process-env
   private shell = process.env.SHELL;
   private _env: NodeJS.ProcessEnv = {};
@@ -32,6 +32,14 @@ export class Ruby {
     workingFolder = vscode.workspace.workspaceFolders![0].uri.fsPath
   ) {
     this.workingFolder = workingFolder;
+  }
+
+  get versionManager() {
+    return this.#versionManager;
+  }
+
+  private set versionManager(versionManager: VersionManager | undefined) {
+    this.#versionManager = versionManager;
   }
 
   get env() {

--- a/src/status.ts
+++ b/src/status.ts
@@ -74,7 +74,7 @@ export class RubyVersionStatus extends StatusItem {
       this.item.text = "Failed to activate Ruby";
       this.item.severity = vscode.LanguageStatusSeverity.Error;
     } else {
-      this.item.text = `Using Ruby ${client.ruby.rubyVersion}`;
+      this.item.text = `Using Ruby ${client.ruby.rubyVersion} with ${client.ruby.versionManager}`;
       this.item.severity = vscode.LanguageStatusSeverity.Information;
     }
   }
@@ -84,7 +84,7 @@ export class RubyVersionStatus extends StatusItem {
       this.item.text = "Failed to activate Ruby";
       this.item.severity = vscode.LanguageStatusSeverity.Error;
     } else {
-      this.item.text = `Using Ruby ${this.client.ruby.rubyVersion}`;
+      this.item.text = `Using Ruby ${this.client.ruby.rubyVersion} with ${this.client.ruby.versionManager}`;
       this.item.severity = vscode.LanguageStatusSeverity.Information;
     }
   }
@@ -94,13 +94,14 @@ export class RubyVersionStatus extends StatusItem {
       vscode.commands.registerCommand(
         Command.SelectVersionManager,
         async () => {
+          const configuration = vscode.workspace.getConfiguration("rubyLsp");
           const options = Object.values(VersionManager);
-          const manager = await vscode.window.showQuickPick(options);
+          const manager = await vscode.window.showQuickPick(options, {
+            placeHolder: `Current: ${configuration.get("rubyVersionManager")}`,
+          });
 
           if (manager !== undefined) {
-            vscode.workspace
-              .getConfiguration("rubyLsp")
-              .update("rubyVersionManager", manager, true, true);
+            configuration.update("rubyVersionManager", manager, true, true);
           }
         }
       )

--- a/src/test/suite/status.test.ts
+++ b/src/test/suite/status.test.ts
@@ -35,7 +35,7 @@ suite("StatusItems", () => {
 
   suite("RubyVersionStatus", () => {
     beforeEach(() => {
-      ruby = { rubyVersion: "3.2.0" } as Ruby;
+      ruby = { rubyVersion: "3.2.0", versionManager: "shadowenv" } as Ruby;
       client = {
         context,
         ruby,
@@ -45,7 +45,7 @@ suite("StatusItems", () => {
     });
 
     test("Status is initialized with the right values", async () => {
-      assert.strictEqual(status.item.text, "Using Ruby 3.2.0");
+      assert.strictEqual(status.item.text, "Using Ruby 3.2.0 with shadowenv");
       assert.strictEqual(status.item.name, "Ruby LSP Status");
       assert.strictEqual(status.item.command?.title, "Change version manager");
       assert.strictEqual(
@@ -56,11 +56,11 @@ suite("StatusItems", () => {
     });
 
     test("Refresh updates version string", async () => {
-      assert.strictEqual(status.item.text, "Using Ruby 3.2.0");
+      assert.strictEqual(status.item.text, "Using Ruby 3.2.0 with shadowenv");
 
       client.ruby.rubyVersion = "3.2.1";
       status.refresh();
-      assert.strictEqual(status.item.text, "Using Ruby 3.2.1");
+      assert.strictEqual(status.item.text, "Using Ruby 3.2.1 with shadowenv");
     });
   });
 


### PR DESCRIPTION
When selecting the version manager, we didn't inform the user in any way about which one is currently selected. This PR just adds that information as the placeholder of the quick pick.