### PR TITLE
Contribute config defaults to exclude .ruby-lsp from search and file tree

### DIFF
--- a/package.json
+++ b/package.json
@@ -224,7 +224,24 @@
         ],
         "configuration": "./languages/erb.json"
       }
-    ]
+    ],
+    "configurationDefaults": {
+      "files.exclude": {
+        "**/.git": true,
+        "**/.svn": true,
+        "**/.hg": true,
+        "**/CVS": true,
+        "**/.DS_Store": true,
+        "**/Thumbs.db": true,
+        "**/.ruby-lsp": true
+      },
+      "search.exclude": {
+        "**/node_modules": true,
+        "**/bower_components": true,
+        "**/*.code-search": true,
+        "**/.ruby-lsp": true
+      }
+    }
   },
   "scripts": {
     "vscode:prepublish": "yarn run esbuild-base --minify",


### PR DESCRIPTION
We should contribute configuration defaults for automatically excluding the `.ruby-lsp` folder from the file tree and search. Especially for search, it's annoying when searching for the `Gemfile` to accidentally find the custom one.