### PR TITLE
Decouple code units

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -34,6 +34,7 @@ export default class Client implements ClientInterface {
   #context: vscode.ExtensionContext;
   #ruby: Ruby;
   #state: ServerState = ServerState.Starting;
+  #onStateChangeEmitter = new vscode.EventEmitter<ClientInterface>();
 
   constructor(
     context: vscode.ExtensionContext,
@@ -203,6 +204,10 @@ export default class Client implements ClientInterface {
     }
   }
 
+  get onStateChange(): vscode.Event<ClientInterface> {
+    return this.#onStateChangeEmitter.event;
+  }
+
   get ruby(): Ruby {
     return this.#ruby;
   }
@@ -225,7 +230,7 @@ export default class Client implements ClientInterface {
 
   private set state(state: ServerState) {
     this.#state = state;
-    this.statusItems.refresh();
+    this.#onStateChangeEmitter.fire(this);
   }
 
   private registerCommands() {

--- a/src/client.ts
+++ b/src/client.ts
@@ -14,7 +14,8 @@ import {
 
 import { Telemetry } from "./telemetry";
 import { Ruby } from "./ruby";
-import { StatusItems, Command, ServerState, ClientInterface } from "./status";
+import { Command, ServerState } from "./enums";
+import { StatusItems, ClientInterface } from "./status";
 
 const LSP_NAME = "Ruby LSP";
 const asyncExec = promisify(exec);

--- a/src/client.ts
+++ b/src/client.ts
@@ -15,7 +15,6 @@ import {
 import { Telemetry } from "./telemetry";
 import { Ruby } from "./ruby";
 import { Command, ServerState } from "./enums";
-import { StatusItems, ClientInterface } from "./status";
 
 const LSP_NAME = "Ruby LSP";
 const asyncExec = promisify(exec);
@@ -25,16 +24,15 @@ interface EnabledFeatures {
   [key: string]: boolean;
 }
 
-export default class Client implements ClientInterface {
+export default class Client {
   private client: LanguageClient | undefined;
   private workingFolder: string;
   private telemetry: Telemetry;
-  private statusItems: StatusItems;
   private outputChannel = vscode.window.createOutputChannel(LSP_NAME);
   #context: vscode.ExtensionContext;
   #ruby: Ruby;
   #state: ServerState = ServerState.Starting;
-  #onStateChangeEmitter = new vscode.EventEmitter<ClientInterface>();
+  #onStateChangeEmitter = new vscode.EventEmitter<Client>();
 
   constructor(
     context: vscode.ExtensionContext,
@@ -45,7 +43,6 @@ export default class Client implements ClientInterface {
     this.telemetry = telemetry;
     this.#context = context;
     this.#ruby = ruby;
-    this.statusItems = new StatusItems(this);
     this.registerCommands();
     this.registerAutoRestarts();
   }
@@ -204,7 +201,7 @@ export default class Client implements ClientInterface {
     }
   }
 
-  get onStateChange(): vscode.Event<ClientInterface> {
+  get onStateChange() {
     return this.#onStateChangeEmitter.event;
   }
 

--- a/src/enums.ts
+++ b/src/enums.ts
@@ -1,0 +1,29 @@
+export enum ServerState {
+  Starting = "Starting",
+  Running = "Running",
+  Stopped = "Stopped",
+  Error = "Error",
+}
+
+// Lists every Command in the Ruby LSP
+export enum Command {
+  Start = "rubyLsp.start",
+  Stop = "rubyLsp.stop",
+  Restart = "rubyLsp.restart",
+  Update = "rubyLsp.update",
+  ToggleExperimentalFeatures = "rubyLsp.toggleExperimentalFeatures",
+  ServerOptions = "rubyLsp.serverOptions",
+  ToggleYjit = "rubyLsp.toggleYjit",
+  SelectVersionManager = "rubyLsp.selectRubyVersionManager",
+  ToggleFeatures = "rubyLsp.toggleFeatures",
+}
+
+export enum VersionManager {
+  Asdf = "asdf",
+  Auto = "auto",
+  Chruby = "chruby",
+  Rbenv = "rbenv",
+  Rvm = "rvm",
+  Shadowenv = "shadowenv",
+  None = "none",
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,8 +3,10 @@ import * as vscode from "vscode";
 import Client from "./client";
 import { Telemetry } from "./telemetry";
 import { Ruby } from "./ruby";
+import { StatusItems } from "./status";
 
 let client: Client;
+let statusItems: StatusItems;
 
 export async function activate(context: vscode.ExtensionContext) {
   const ruby = new Ruby();
@@ -12,6 +14,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
   const telemetry = new Telemetry(context);
   client = new Client(context, telemetry, ruby);
+  statusItems = new StatusItems(client);
 
   await client.start();
 }
@@ -19,5 +22,8 @@ export async function activate(context: vscode.ExtensionContext) {
 export async function deactivate(): Promise<void> {
   if (client) {
     return client.stop();
+  }
+  if (statusItems) {
+    statusItems.dispose();
   }
 }

--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -5,17 +5,9 @@ import fs from "fs";
 
 import * as vscode from "vscode";
 
-const asyncExec = promisify(exec);
+import { VersionManager } from "./enums";
 
-export enum VersionManager {
-  Asdf = "asdf",
-  Auto = "auto",
-  Chruby = "chruby",
-  Rbenv = "rbenv",
-  Rvm = "rvm",
-  Shadowenv = "shadowenv",
-  None = "none",
-}
+const asyncExec = promisify(exec);
 
 export class Ruby {
   public rubyVersion?: string;

--- a/src/status.ts
+++ b/src/status.ts
@@ -18,6 +18,7 @@ export interface ClientInterface {
   context: vscode.ExtensionContext;
   ruby: Ruby;
   state: ServerState;
+  onStateChange: vscode.Event<ClientInterface>;
 }
 
 export abstract class StatusItem {
@@ -319,6 +320,7 @@ export class StatusItems {
       new FeaturesStatus(client),
     ];
     this.refresh();
+    client.onStateChange(this.refresh, this);
   }
 
   public refresh(): void {

--- a/src/status.ts
+++ b/src/status.ts
@@ -1,26 +1,7 @@
 import * as vscode from "vscode";
 
-import { Ruby, VersionManager } from "./ruby";
-
-export enum ServerState {
-  Starting = "Starting",
-  Running = "Running",
-  Stopped = "Stopped",
-  Error = "Error",
-}
-
-// Lists every Command in the Ruby LSP
-export enum Command {
-  Start = "rubyLsp.start",
-  Stop = "rubyLsp.stop",
-  Restart = "rubyLsp.restart",
-  Update = "rubyLsp.update",
-  ToggleExperimentalFeatures = "rubyLsp.toggleExperimentalFeatures",
-  ServerOptions = "rubyLsp.serverOptions",
-  ToggleYjit = "rubyLsp.toggleYjit",
-  SelectVersionManager = "rubyLsp.selectRubyVersionManager",
-  ToggleFeatures = "rubyLsp.toggleFeatures",
-}
+import { Command, ServerState, VersionManager } from "./enums";
+import { Ruby } from "./ruby";
 
 const STOPPED_SERVER_OPTIONS = [
   { label: "Ruby LSP: Start", description: Command.Start },


### PR DESCRIPTION
Currently most of our extension logic revolves around the `Client` class, and it ends up orchestrating all the other functionality in the extension. However, that creates unnecessary dependencies between the `Client` unit and other units.

Instead, it should be the top level extension that manages the separate units and any interaction between said units should happen via events, as appropriate.

For that reason, this PR refactors the extension heavily to introduce:

1. A top level `Extension` class that encapsulates the creation/activation/deactivation logic for all related units.
2. A separate unit to hold all the `enum` definitions.
3. An `onStateChanged` event on the `Client` class that can be used to watch for and respond to state changes. The `StatusItems` class uses that to call the `refresh` method on individual status items as appropriate.
4. As a corollary to the previous step, individual status items don't need to hold a reference to any kind of client or context object and can simply use the object passed as event argument.