### PR TITLE
Always use the system bundler path

### DIFF
--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -180,6 +180,10 @@ export class Ruby {
         ".ruby-lsp",
         "Gemfile"
       );
+
+      // We must use the default system path for bundler in case someone has BUNDLE_PATH configured. Otherwise, we end
+      // up with all gems installed inside of the `.ruby-lsp` folder, which may lead to all sorts of errors
+      this._env.BUNDLE_PATH__SYSTEM = "true";
     }
   }
 

--- a/src/test/suite/ruby.test.ts
+++ b/src/test/suite/ruby.test.ts
@@ -38,6 +38,7 @@ suite("Ruby environment activation", () => {
       "fake/some/project/.ruby-lsp/Gemfile",
       "Expected BUNDLE_GEMFILE to be set"
     );
+    assert.strictEqual(ruby.env.BUNDLE_PATH__SYSTEM, "true");
   });
 
   test("Activate fetches Ruby information when working on the Ruby LSP", async () => {
@@ -55,5 +56,6 @@ suite("Ruby environment activation", () => {
       undefined,
       "Expected BUNDLE_GEMFILE to not be set for the ruby-lsp folder"
     );
+    assert.strictEqual(ruby.env.BUNDLE_PATH__SYSTEM, undefined);
   });
 });


### PR DESCRIPTION
If a user configures `BUNDLE_PATH`, then we end up installing gems inside of the `.ruby-lsp` directory, which leads to all sorts of problems.

To override the user's `BUNDLE_PATH` configuration, we can set `BUNDLE_PATH__SYSTEM` to `true`, which forces bundler to use the default system paths.