### PR TITLE
Use path.basename instead of endsWith to check project folders

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -242,7 +242,7 @@ export default class Client implements ClientInterface {
   private async setupCustomGemfile() {
     // If we're working on the ruby-lsp itself, we can't create a custom Gemfile or we'd be trying to activate the same
     // gem twice
-    if (this.workingFolder.endsWith("ruby-lsp")) {
+    if (path.basename(this.workingFolder) === "ruby-lsp") {
       await this.bundleInstall();
       return;
     }
@@ -360,7 +360,7 @@ export default class Client implements ClientInterface {
   // Leave this function for a while to assist users migrating from the old version of the extension
   private async migrateFromIncludingInBundle(): Promise<boolean> {
     // When working on the Ruby LSP itself, it's always included in the bundle
-    if (this.workingFolder.endsWith("ruby-lsp")) {
+    if (path.basename(this.workingFolder) === "ruby-lsp") {
       return false;
     }
 

--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -174,7 +174,7 @@ export class Ruby {
   private setupBundlePath() {
     // Use our custom Gemfile to allow RuboCop and extensions to work without having to add ruby-lsp to the bundle. Note
     // that we can't do this for the ruby-lsp repository itself otherwise the gem is activated twice
-    if (!this.workingFolder.endsWith("ruby-lsp")) {
+    if (path.basename(this.workingFolder) !== "ruby-lsp") {
       this._env.BUNDLE_GEMFILE = path.join(
         this.workingFolder,
         ".ruby-lsp",


### PR DESCRIPTION
We only want to avoid the custom bundle when working on the `ruby-lsp` project itself. However, checking it using `endsWith` is brittle since we could name a server extension as `rails-ruby-lsp` or something, which would match accidentally.

Using `basename` guarantees that we're comparing just the last portion of the path.