### PR TITLE
Run entire test class in terminal

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,6 +117,11 @@
               "description": "Enable completion, which provides suggestions for code completion",
               "type": "boolean",
               "default": true
+            },
+            "codeLens": {
+              "description": "Enable code lens, which generates clickable text above tests to run them in the terminal",
+              "type": "boolean",
+              "default": false
             }
           },
           "default": {
@@ -132,7 +137,8 @@
             "onTypeFormatting": true,
             "selectionRanges": true,
             "semanticHighlighting": true,
-            "completion": true
+            "completion": true,
+            "codeLens": false
           }
         },
         "rubyLsp.rubyVersionManager": {

--- a/src/status.ts
+++ b/src/status.ts
@@ -20,6 +20,7 @@ export enum Command {
   ToggleYjit = "rubyLsp.toggleYjit",
   SelectVersionManager = "rubyLsp.selectRubyVersionManager",
   ToggleFeatures = "rubyLsp.toggleFeatures",
+  RunTest = "rubyLsp.runTest",
 }
 
 const STOPPED_SERVER_OPTIONS = [

--- a/src/test/suite/status.test.ts
+++ b/src/test/suite/status.test.ts
@@ -196,6 +196,9 @@ suite("StatusItems", () => {
     const configuration = vscode.workspace.getConfiguration("rubyLsp");
     const originalFeatures: { [key: string]: boolean } =
       configuration.get("enabledFeatures")!;
+    const numberOfExperimentalFeatures = Object.values(originalFeatures).filter(
+      (feature) => feature === false
+    ).length;
     const numberOfFeatures = Object.keys(originalFeatures).length;
 
     beforeEach(() => {
@@ -214,7 +217,9 @@ suite("StatusItems", () => {
     test("Status is initialized with the right values", async () => {
       assert.strictEqual(
         status.item.text,
-        `${numberOfFeatures}/${numberOfFeatures} features enabled`
+        `${
+          numberOfFeatures - numberOfExperimentalFeatures
+        }/${numberOfFeatures} features enabled`
       );
       assert.strictEqual(status.item.name, "Ruby LSP Features");
       assert.strictEqual(status.item.command?.title, "Manage");
@@ -241,7 +246,9 @@ suite("StatusItems", () => {
           status.refresh();
           assert.strictEqual(
             status.item.text,
-            `${numberOfFeatures - 1}/${numberOfFeatures} features enabled`
+            `${
+              numberOfFeatures - numberOfExperimentalFeatures - 1
+            }/${numberOfFeatures} features enabled`
           );
         });
     });


### PR DESCRIPTION
### Description

The first step of #498 (related to https://github.com/Shopify/ruby-lsp/pull/598)

Creates the `rubyLsp.runTest` VSCode command that is used in the `CodeLens` request [here](https://github.com/Shopify/ruby-lsp/pull/598/files#diff-9032a8992a4018ba0a0d29b93314fa22ef0ded7889412ccf05fd6125a36f728aR55). This command runs the entire test class in a terminal when `Run` is clicked.

![code_lens](https://user-images.githubusercontent.com/38566184/228671264-4cfbcc48-81ac-4886-951c-25c222b24999.gif)

### Manual Testing

1. Debug this branch on the [`al/add-code-lens`](https://github.com/Shopify/ruby-lsp/tree/al/add-code-lens) branch of the Ruby LSP.
2. Open up a test file (ex. `test/document_test.rb`)
3. Observe there is an option to "Run" above the class declaration
4. Click "Run"
5. Observe the terminal is opened and the tests are run
6. Navigate to a non-test Ruby file. Observe the option to "Run" does not appear.