### PR TITLE
Also "activate" ruby if `VersionManager.none` was specified

### DIFF
--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -77,6 +77,7 @@ export class Ruby {
           await this.activate("rvm-auto-ruby");
           break;
         case VersionManager.None:
+          await this.activate("ruby");
           break;
         default:
           await this.activateShadowenv();


### PR DESCRIPTION
Currently if `VersionManager.none` was specified, ruby will load from system default path.

Which won't load `~/.bashrc` or `~/.zshrc` like other `VersionManager` option. For macOS, it will always use the system integrated ruby, which is not a good news for homebrew installed ruby.

So I think it might be better to also "activate" ruby when using `VersionManager.none`.