### PR TITLE
Do not attempt to run server on old rubies

### DIFF
--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -148,7 +148,15 @@ export class Ruby {
     this.yjitEnabled = yjitIsDefined === "constant";
 
     const [major, minor, _patch] = this.rubyVersion.split(".").map(Number);
-    this.supportsYjit = this.yjitEnabled && [major, minor] >= [3, 2];
+
+    if ((major === 2 && minor < 7) || major < 2) {
+      throw new Error(
+        "The Ruby LSP requires Ruby 2.7 or newer to run. Please upgrade your Ruby version"
+      );
+    }
+
+    this.supportsYjit =
+      this.yjitEnabled && (major > 3 || (major === 3 && minor >= 2));
 
     const useYjit = vscode.workspace.getConfiguration("rubyLsp").get("yjit");
 


### PR DESCRIPTION
Closes #508

The `ruby-lsp` gem requires Ruby >= 2.7 to run. If someone tries to use an older one, we just try to boot it which surfaces issues later and results in a frustrating experience.

This PR just throws an error from our Ruby activation if the version is smaller than 2.7. The user will get notified that we're not going to activate and we prevent the server from trying to boot.