### PR TITLE
Detect `ruby-lsp` being in the `Gemfile` through `Bundler`

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -352,13 +352,9 @@ export default class Client implements ClientInterface {
   }
 
   private async rubyLspIsInBundle(): Promise<boolean> {
-    // When working on the Ruby LSP itself, it's always included in the bundle
-    if (path.basename(this.workingFolder) === "ruby-lsp") {
-      return true;
-    }
-
     try {
-      // detect if ruby-lsp is a direct dependency, but ignore if it's transitive
+      // exit with an error if ruby-lsp not a dependency or is a transitive dependency.
+      // exit with success if ruby-lsp is a direct dependency.
       await asyncExec(
         `BUNDLE_GEMFILE=${path.join(
           this.workingFolder,

--- a/src/client.ts
+++ b/src/client.ts
@@ -358,12 +358,12 @@ export default class Client implements ClientInterface {
     }
 
     try {
-      // If bundle show succeeds, it means the ruby-lsp gem is a part of the bundle
+      // detect if ruby-lsp is a direct dependency, but ignore if it's transitive
       await asyncExec(
         `BUNDLE_GEMFILE=${path.join(
           this.workingFolder,
           "Gemfile"
-        )} bundle show ruby-lsp`,
+        )} bundle exec ruby -e "exit 1 unless Bundler.locked_gems.dependencies.key?('ruby-lsp')"`,
         {
           cwd: this.workingFolder,
           env: this.ruby.env,


### PR DESCRIPTION
Closes #500

## Tophatting

* Open a project which doesn't contain `ruby-lsp` in the Gemfile, e.g. `code-db`.
* Ensure that `.ruby-lsp/Gemfile` exists with an entry for `ruby-lsp`
* Add `ruby-lsp` to the Gemfile
* Reload the window
* Ensure that `.ruby-lsp/Gemfile` exists with a **commented out** entry for `ruby-lsp`