### PR TITLE
Abort existing bundle install if another restart is triggered

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -442,6 +442,7 @@ export default class Client implements ClientInterface {
       (progress, token) => {
         if (this.bundleInstallCancellationSource) {
           this.bundleInstallCancellationSource.cancel();
+          this.bundleInstallCancellationSource.dispose();
         }
 
         this.bundleInstallCancellationSource =
@@ -449,6 +450,7 @@ export default class Client implements ClientInterface {
 
         token.onCancellationRequested(() => {
           this.bundleInstallCancellationSource!.cancel();
+          this.bundleInstallCancellationSource!.dispose();
         });
 
         return this.bundleInstall(customGemfilePath, {


### PR DESCRIPTION
Closes #510

Use a cancellation source to abort existing bundle install processes if restart is triggered in the middle. This avoids having multiple progress windows (and multiple processes) trying to bundle install.