### PR TITLE
Allow specifying a custom bundle gemfile path

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,16 @@ The tool to be used for formatting files can be configured with the following se
 "rubyLsp.formatter": "auto"
 ```
 
+#### Using a custom Gemfile
+
+If you are working on a project using an older version of Ruby not supported by Ruby LSP, then you will need you specify a separate `Gemfile` for development tools. You can include the `ruby-lsp` in it and point to that Gemfile by using the following configuration:
+
+**Note**: when using this, gems will not be installed automatically and neither will `ruby-lsp` upgrades.
+
+```jsonc
+"rubyLsp.bundleGemfile": "relative/path/to/Gemfile"
+```
+
 ## Features
 
 ![Ruby LSP demo](extras/ruby_lsp_demo.gif)

--- a/package.json
+++ b/package.json
@@ -164,6 +164,11 @@
             "none"
           ],
           "default": "auto"
+        },
+        "rubyLsp.bundleGemfile": {
+          "description": "Relative path to the Gemfile to use for bundling the Ruby LSP server. Only necessary when using a separate Gemfile for the Ruby LSP",
+          "type": "string",
+          "default": ""
         }
       }
     },

--- a/src/client.ts
+++ b/src/client.ts
@@ -61,7 +61,15 @@ export default class Client implements ClientInterface {
     this.state = ServerState.Starting;
 
     try {
-      await this.setupCustomGemfile();
+      // When using a custom bundle path that is not our default, then we shouldn't create the .ruby-lsp folder or try to
+      // install gems
+      const customBundleGemfile: string = vscode.workspace
+        .getConfiguration("rubyLsp")
+        .get("bundleGemfile")!;
+
+      if (customBundleGemfile.length === 0) {
+        await this.setupCustomGemfile();
+      }
     } catch (error: any) {
       this.state = ServerState.Error;
 


### PR DESCRIPTION
Closes Shopify/ruby-lsp#1496

Allow configuring the path to a Gemfile separate from the project to use for the Ruby LSP and other developer tools such as RuboCop. This allows people who are working on projects with older Ruby versions to still use the LSP from a different bundle.