### PR TITLE
Source shell configuration files manually

### DIFF
--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -125,7 +125,7 @@ export class Ruby {
 
   private async activate(ruby: string) {
     const result = await asyncExec(
-      `${this.shell} -lic '${ruby} --disable-gems -rjson -e "printf(%{RUBY_ENV_ACTIVATE%sRUBY_ENV_ACTIVATE}, JSON.dump(ENV.to_h))"'`,
+      `${this.shell} -ic '${ruby} --disable-gems -rjson -e "printf(%{RUBY_ENV_ACTIVATE%sRUBY_ENV_ACTIVATE}, JSON.dump(ENV.to_h))"'`,
       { cwd: this.workingFolder }
     );
 


### PR DESCRIPTION
Closes #505

In #349, we tried to switch manually sourcing shell configuration files for using the `-i` flag for interactive mode. Unfortunately, that doesn't seem to always work because interactive mode tries to load other stuff we don't need, such as `~/.profile` or `~/.bash_profile`.

It seems less brittle to just manually source the rc files ourselves.