### PR TITLE
Add Ruby debug client

### DIFF
--- a/package.json
+++ b/package.json
@@ -178,6 +178,65 @@
         }
       }
     },
+    "breakpoints": [
+      {
+        "language": "ruby"
+      }
+    ],
+    "debuggers": [
+      {
+        "type": "ruby_lsp",
+        "label": "Ruby LSP debug client",
+        "languages": [
+          "ruby"
+        ],
+        "configurationAttributes": {
+          "launch": {
+            "required": [
+              "program"
+            ],
+            "properties": {
+              "program": {
+                "type": "string",
+                "description": "The program to debug"
+              }
+            }
+          },
+          "attach": {}
+        },
+        "configurationSnippets": [
+          {
+            "label": "Debug a Ruby program",
+            "description": "New configuration for debugging a Ruby program",
+            "body": {
+              "type": "ruby_lsp",
+              "request": "launch",
+              "name": "Debug program",
+              "program": "ruby ${file}"
+            }
+          },
+          {
+            "label": "Debug a Minitest / Test Unit file",
+            "description": "New configuration for debugging a Minitest / Test Unit file",
+            "body": {
+              "type": "ruby_lsp",
+              "request": "launch",
+              "name": "Debug test file",
+              "program": "ruby -Itest ${relativeFile}"
+            }
+          },
+          {
+            "label": "Attach the debugger to a running Ruby process",
+            "description": "New configuration for attaching the debugger to a process that was started with the debugger",
+            "body": {
+              "type": "ruby_lsp",
+              "request": "attach",
+              "name": "Attach to a debuggee"
+            }
+          }
+        ]
+      }
+    ],
     "snippets": [
       {
         "language": "ruby",

--- a/src/client.ts
+++ b/src/client.ts
@@ -293,6 +293,8 @@ export default class Client implements ClientInterface {
 
     const gemEntry =
       'gem "ruby-lsp", require: false, group: :development, source: "https://rubygems.org"';
+    const debugEntry =
+      'gem "debug", require: false, group: :development, platforms: :mri, source: "https://rubygems.org"';
 
     // Only try to evaluate the top level Gemfile if there is one. Otherwise, we'll just create our own Gemfile
     if (fs.existsSync(path.join(this.workingFolder, "Gemfile"))) {
@@ -300,16 +302,22 @@ export default class Client implements ClientInterface {
       gemfile.push('eval_gemfile(File.expand_path("../Gemfile", __dir__))');
 
       // If the `ruby-lsp` exists in the bundle, add it to the custom Gemfile commented out
-      if (await this.rubyLspIsInBundle()) {
+      if (await this.projectHasDependency("ruby-lsp")) {
         // If it is already in the bundle, add the gem commented out to avoid conflicts
         gemfile.push(`# ${gemEntry}`);
       } else {
         // If it's not a part of the bundle, add it to the custom Gemfile
         gemfile.push(gemEntry);
       }
+
+      // If debug is not in the bundle, add it to allow debugging
+      if (!(await this.projectHasDependency("debug"))) {
+        gemfile.push(debugEntry);
+      }
     } else {
-      // If no Gemfile exists, add the `ruby-lsp` gem to the custom Gemfile
+      // If no Gemfile exists, add the `ruby-lsp` and `debug` to the custom Gemfile
       gemfile.push(gemEntry);
+      gemfile.push(debugEntry);
     }
 
     // Add an empty line at the end of the file
@@ -377,15 +385,15 @@ export default class Client implements ClientInterface {
     return Object.keys(features).filter((key) => features[key]);
   }
 
-  private async rubyLspIsInBundle(): Promise<boolean> {
+  private async projectHasDependency(gemName: string): Promise<boolean> {
     try {
-      // exit with an error if ruby-lsp not a dependency or is a transitive dependency.
-      // exit with success if ruby-lsp is a direct dependency.
+      // exit with an error if gemName not a dependency or is a transitive dependency.
+      // exit with success if gemName is a direct dependency.
       await asyncExec(
         `BUNDLE_GEMFILE=${path.join(
           this.workingFolder,
           "Gemfile"
-        )} bundle exec ruby -e "exit 1 unless Bundler.locked_gems.dependencies.key?('ruby-lsp')"`,
+        )} bundle exec ruby -e "exit 1 unless Bundler.locked_gems.dependencies.key?('${gemName}')"`,
         {
           cwd: this.workingFolder,
           env: this.ruby.env,

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -1,0 +1,231 @@
+import path from "path";
+import fs from "fs";
+import { ChildProcessWithoutNullStreams, spawn } from "child_process";
+
+import * as vscode from "vscode";
+
+import { Ruby } from "./ruby";
+
+export class Debugger
+  implements
+    vscode.DebugAdapterDescriptorFactory,
+    vscode.DebugConfigurationProvider
+{
+  private workingFolder: string;
+  private ruby: Ruby;
+  private debugProcess?: ChildProcessWithoutNullStreams;
+  private console = vscode.debug.activeDebugConsole;
+  private subscriptions: vscode.Disposable[];
+
+  constructor(
+    context: vscode.ExtensionContext,
+    ruby: Ruby,
+    workingFolder = vscode.workspace.workspaceFolders![0].uri.fsPath
+  ) {
+    this.ruby = ruby;
+    this.subscriptions = [
+      vscode.debug.registerDebugConfigurationProvider("ruby_lsp", this),
+      vscode.debug.registerDebugAdapterDescriptorFactory("ruby_lsp", this),
+    ];
+    this.workingFolder = workingFolder;
+
+    context.subscriptions.push(...this.subscriptions);
+  }
+
+  // This is where we start the debuggee process. We currently support launching with the debugger or attaching to a
+  // process that was already booted with the debugger
+  async createDebugAdapterDescriptor(
+    session: vscode.DebugSession,
+    _executable: vscode.DebugAdapterExecutable
+  ): Promise<vscode.DebugAdapterDescriptor | undefined> {
+    if (session.configuration.request === "launch") {
+      return this.spawnDebuggeeForLaunch(session);
+    } else if (session.configuration.request === "attach") {
+      return this.attachDebuggee();
+    } else {
+      return new Promise((_resolve, reject) =>
+        reject(
+          new Error(
+            `Unknown request type: ${session.configuration.request}. Please review your launch configurations`
+          )
+        )
+      );
+    }
+  }
+
+  provideDebugConfigurations?(
+    _folder: vscode.WorkspaceFolder | undefined,
+    _token?: vscode.CancellationToken
+  ): vscode.ProviderResult<vscode.DebugConfiguration[]> {
+    return [
+      {
+        type: "ruby_lsp",
+        name: "Debug",
+        request: "launch",
+        // eslint-disable-next-line no-template-curly-in-string
+        program: "ruby ${file}",
+        env: this.ruby.env,
+      },
+      {
+        type: "ruby_lsp",
+        name: "Debug",
+        request: "launch",
+        // eslint-disable-next-line no-template-curly-in-string
+        program: "ruby -Itest ${relativeFile}",
+        env: this.ruby.env,
+      },
+      {
+        type: "ruby_lsp",
+        name: "Debug",
+        request: "attach",
+        env: this.ruby.env,
+      },
+    ];
+  }
+
+  // Resolve the user's debugger configuration. Here we receive what is configured in launch.json and can modify and
+  // insert defaults for the user. The most important thing is making sure the Ruby environment is a part of it so that
+  // we launch using the right bundle and Ruby version
+  resolveDebugConfiguration?(
+    _folder: vscode.WorkspaceFolder | undefined,
+    debugConfiguration: vscode.DebugConfiguration,
+    _token?: vscode.CancellationToken
+  ): vscode.ProviderResult<vscode.DebugConfiguration> {
+    // If the user has their own debug launch configurations, we still need to inject the Ruby environment
+    debugConfiguration.env = this.ruby.env;
+    return debugConfiguration;
+  }
+
+  dispose() {
+    if (this.debugProcess) {
+      this.debugProcess.kill("SIGTERM");
+    }
+
+    this.subscriptions.forEach((subscription) => subscription.dispose());
+  }
+
+  private attachDebuggee(): Promise<vscode.DebugAdapterDescriptor | undefined> {
+    // When using attach, a process will be launched using Ruby debug and it will create a socket automatically. We have
+    // to find the available sockets and ask the user which one they want to attach to
+    const socketsDir = path.join("/", "tmp", "ruby-lsp-debug-sockets");
+    const sockets = fs
+      .readdirSync(socketsDir)
+      .map((file) => file)
+      .filter((file) => file.endsWith(".sock"));
+
+    return new Promise((resolve, reject) => {
+      if (sockets.length === 0) {
+        reject(new Error("No debuggee processes found"));
+      }
+
+      return vscode.window
+        .showQuickPick(sockets, {
+          placeHolder: "Select a debuggee",
+          ignoreFocusOut: true,
+        })
+        .then((selectedSocket) => {
+          if (selectedSocket === undefined) {
+            reject(new Error("No debuggee selected"));
+          } else {
+            resolve(
+              new vscode.DebugAdapterNamedPipeServer(
+                path.join(socketsDir, selectedSocket)
+              )
+            );
+          }
+        });
+    });
+  }
+
+  private spawnDebuggeeForLaunch(
+    session: vscode.DebugSession
+  ): Promise<vscode.DebugAdapterDescriptor | undefined> {
+    let initialMessage = "";
+    const sockPath = this.socketPath();
+
+    return new Promise((resolve, reject) => {
+      this.debugProcess = spawn(
+        "bundle",
+        [
+          "exec",
+          "rdbg",
+          "--open",
+          "--command",
+          `--sock-path=${sockPath}`,
+          "--",
+          session.configuration.program,
+        ],
+        {
+          env: this.ruby.env,
+          cwd: this.workingFolder,
+        }
+      );
+
+      this.debugProcess.stderr.on("data", (data) => {
+        const message = data.toString();
+        // Print whatever data we get in stderr in the debug console since it might be relevant for the user
+        this.console.append(message);
+
+        // When stderr includes a complete wait for debugger connection message, then we're done initializing and can
+        // resolve the promise. If we try to resolve earlier, VS Code will simply fail to connect
+        if (
+          initialMessage.includes("DEBUGGER: wait for debugger connection...")
+        ) {
+          resolve(new vscode.DebugAdapterNamedPipeServer(sockPath));
+        } else {
+          initialMessage += message;
+        }
+      });
+
+      // Anything printed by debug to stdout we want to show in the debug console
+      this.debugProcess.stdout.on("data", (data) => {
+        this.console.append(data.toString());
+      });
+
+      // If any errors occur in the server, we have to show that in the debug console and reject the promise
+      this.debugProcess.on("error", (error) => {
+        this.console.append(error.message);
+        reject(error);
+      });
+
+      // If the Ruby debug exits with an exit code > 1, then an error might've occurred. The reason we don't use only
+      // code zero here is because debug actually exits with 1 if the user cancels the debug session, which is not
+      // actually an error
+      this.debugProcess.on("exit", (code) => {
+        if (code && code > 1) {
+          const message = `
+          Debuggee failed to launch "${session.configuration.program}" with exit status ${code}. This may indicate an
+          issue with your launch configurations.`;
+
+          this.console.append(message);
+          reject(new Error(message));
+        }
+      });
+    });
+  }
+
+  // Generate a socket path so that Ruby debug doesn't have to create one for us. This makes coordination easier since
+  // we always know the path to the socket
+  private socketPath() {
+    const socketsDir = path.join("/", "tmp", "ruby-lsp-debug-sockets");
+    if (!fs.existsSync(socketsDir)) {
+      fs.mkdirSync(socketsDir);
+    }
+
+    let socketIndex = 0;
+    const prefix = `ruby-debug-${path.basename(this.workingFolder)}`;
+    const existingSockets = fs
+      .readdirSync(socketsDir)
+      .map((file) => file)
+      .filter((file) => file.startsWith(prefix))
+      .sort();
+
+    if (existingSockets.length > 0) {
+      socketIndex = Number(
+        existingSockets[existingSockets.length - 1].match(/-(\d+).sock$/)![1]
+      );
+    }
+
+    return `${socketsDir}/${prefix}-${socketIndex}.sock`;
+  }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,8 +3,10 @@ import * as vscode from "vscode";
 import Client from "./client";
 import { Telemetry } from "./telemetry";
 import { Ruby } from "./ruby";
+import { Debugger } from "./debugger";
 
 let client: Client;
+let debug: Debugger;
 
 export async function activate(context: vscode.ExtensionContext) {
   const ruby = new Ruby();
@@ -14,10 +16,15 @@ export async function activate(context: vscode.ExtensionContext) {
   client = new Client(context, telemetry, ruby);
 
   await client.start();
+  debug = new Debugger(context, ruby);
 }
 
 export async function deactivate(): Promise<void> {
   if (client) {
     return client.stop();
+  }
+
+  if (debug) {
+    return debug.dispose();
   }
 }

--- a/src/test/suite/debugger.test.ts
+++ b/src/test/suite/debugger.test.ts
@@ -1,0 +1,60 @@
+import * as assert from "assert";
+
+import * as vscode from "vscode";
+
+import { Debugger } from "../../debugger";
+import { Ruby } from "../../ruby";
+
+suite("Debugger", () => {
+  test("Provide debug configurations returns the default configs", () => {
+    const context = { subscriptions: [] } as unknown as vscode.ExtensionContext;
+    const ruby = { env: {} } as Ruby;
+    const debug = new Debugger(context, ruby, "fake");
+    const configs = debug.provideDebugConfigurations!(undefined);
+    assert.deepEqual(
+      [
+        {
+          type: "ruby_lsp",
+          name: "Debug",
+          request: "launch",
+          // eslint-disable-next-line no-template-curly-in-string
+          program: "ruby ${file}",
+          env: ruby.env,
+        },
+        {
+          type: "ruby_lsp",
+          name: "Debug",
+          request: "launch",
+          // eslint-disable-next-line no-template-curly-in-string
+          program: "ruby -Itest ${relativeFile}",
+          env: ruby.env,
+        },
+        {
+          type: "ruby_lsp",
+          name: "Debug",
+          request: "attach",
+          env: ruby.env,
+        },
+      ],
+      configs
+    );
+
+    debug.dispose();
+  });
+
+  test("Resolve configuration injects Ruby environment", () => {
+    const context = { subscriptions: [] } as unknown as vscode.ExtensionContext;
+    const ruby = { env: { bogus: "hello!" } } as unknown as Ruby;
+    const debug = new Debugger(context, ruby, "fake");
+    const configs: any = debug.resolveDebugConfiguration!(undefined, {
+      type: "ruby_lsp",
+      name: "Debug",
+      request: "launch",
+      // eslint-disable-next-line no-template-curly-in-string
+      program: "ruby ${file}",
+    });
+
+    assert.strictEqual(ruby.env, configs.env);
+    debug.dispose();
+  });
+});


### PR DESCRIPTION
Add a client for the Ruby debug gem. Having the debugger client in the Ruby LSP extension itself allows us to do integrations with the language server quite easily, such as displaying current values in a debug session using [the inline value request](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_inlineValue) or adding a `debug` code lens to launch a test directly in debug mode.

We tested this for launch and attach and it works well. It even allows us to attach to a running process of the Ruby LSP, which makes debugging the server a much much easier task.

**Note**: I have intentionally not added any documentation yet. We need to first test this out and make sure it works properly before documenting and advertising it.