### PR TITLE
Improve Ruby test robustness

### DIFF
--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -50,10 +50,12 @@ export class Ruby {
     return this._error;
   }
 
-  async activateRuby() {
-    this.versionManager = vscode.workspace
+  async activateRuby(
+    versionManager: VersionManager = vscode.workspace
       .getConfiguration("rubyLsp")
-      .get("rubyVersionManager")!;
+      .get("rubyVersionManager")!
+  ) {
+    this.versionManager = versionManager;
 
     // If the version manager is auto, discover the actual manager before trying to activate anything
     if (this.versionManager === VersionManager.Auto) {

--- a/src/test/suite/ruby.test.ts
+++ b/src/test/suite/ruby.test.ts
@@ -1,31 +1,13 @@
 import * as assert from "assert";
 
-import { before, after } from "mocha";
-import * as vscode from "vscode";
-
-import { Ruby } from "../../ruby";
+import { Ruby, VersionManager } from "../../ruby";
 
 suite("Ruby environment activation", () => {
   let ruby: Ruby;
-  const configuration = vscode.workspace.getConfiguration("rubyLsp");
-  const currentManager = configuration.get("rubyVersionManager")!;
-
-  before(async () => {
-    await configuration.update("rubyVersionManager", "none", true, true);
-  });
-
-  after(async () => {
-    await configuration.update(
-      "rubyVersionManager",
-      currentManager,
-      true,
-      true
-    );
-  });
 
   test("Activate fetches Ruby information when outside of Ruby LSP", async () => {
     ruby = new Ruby("fake/some/project");
-    await ruby.activateRuby();
+    await ruby.activateRuby(VersionManager.None);
 
     assert.ok(ruby.rubyVersion, "Expected Ruby version to be set");
     assert.strictEqual(
@@ -43,7 +25,7 @@ suite("Ruby environment activation", () => {
 
   test("Activate fetches Ruby information when working on the Ruby LSP", async () => {
     ruby = new Ruby("/fake/ruby-lsp");
-    await ruby.activateRuby();
+    await ruby.activateRuby(VersionManager.None);
 
     assert.ok(ruby.rubyVersion, "Expected Ruby version to be set");
     assert.strictEqual(


### PR DESCRIPTION
Unfortunately, interacting with VS Code configuration are making the tests flaky. And locally it's inconvenient because it will actually update your real settings.

This PR just allows us to inject the version manager from the tests, which removes the need to interact with configurations.