### PR TITLE
Use valid paths for Ruby test

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@ import { Ruby } from "./ruby";
 let client: Client;
 
 export async function activate(context: vscode.ExtensionContext) {
-  const ruby = new Ruby();
+  const ruby = new Ruby(context);
   await ruby.activateRuby();
 
   const telemetry = new Telemetry(context);

--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -27,10 +27,13 @@ export class Ruby {
   private shell = process.env.SHELL;
   private _env: NodeJS.ProcessEnv = {};
   private _error = false;
+  private context: vscode.ExtensionContext;
 
   constructor(
+    context: vscode.ExtensionContext,
     workingFolder = vscode.workspace.workspaceFolders![0].uri.fsPath
   ) {
+    this.context = context;
     this.workingFolder = workingFolder;
   }
 
@@ -90,6 +93,12 @@ export class Ruby {
       this._error = false;
     } catch (error: any) {
       this._error = true;
+
+      // When running tests, we need to throw the error or else activation may silently fail and it's very difficult to
+      // debug
+      if (this.context.extensionMode === vscode.ExtensionMode.Test) {
+        throw error;
+      }
 
       await vscode.window.showErrorMessage(
         `Failed to activate ${this.versionManager} environment: ${error.message}`

--- a/src/test/suite/ruby.test.ts
+++ b/src/test/suite/ruby.test.ts
@@ -1,43 +1,36 @@
 import * as assert from "assert";
 
+import * as vscode from "vscode";
+
 import { Ruby, VersionManager } from "../../ruby";
 
 suite("Ruby environment activation", () => {
   let ruby: Ruby;
 
   test("Activate fetches Ruby information when outside of Ruby LSP", async () => {
-    ruby = new Ruby("fake/some/project");
+    // eslint-disable-next-line no-process-env
+    process.env.SHELL = "/bin/bash";
+
+    const context = {
+      extensionMode: vscode.ExtensionMode.Test,
+    } as vscode.ExtensionContext;
+
+    // eslint-disable-next-line no-process-env
+    ruby = new Ruby(context, process.env.PWD);
     await ruby.activateRuby(VersionManager.None);
 
     assert.ok(ruby.rubyVersion, "Expected Ruby version to be set");
     assert.strictEqual(
       ruby.supportsYjit,
-      false,
+      true,
       "Expected YJIT support to be enabled"
     );
     assert.strictEqual(
       ruby.env.BUNDLE_GEMFILE,
-      "fake/some/project/.ruby-lsp/Gemfile",
+      // eslint-disable-next-line no-process-env
+      `${process.env.PWD}/.ruby-lsp/Gemfile`,
       "Expected BUNDLE_GEMFILE to be set"
     );
     assert.strictEqual(ruby.env.BUNDLE_PATH__SYSTEM, "true");
-  });
-
-  test("Activate fetches Ruby information when working on the Ruby LSP", async () => {
-    ruby = new Ruby("/fake/ruby-lsp");
-    await ruby.activateRuby(VersionManager.None);
-
-    assert.ok(ruby.rubyVersion, "Expected Ruby version to be set");
-    assert.strictEqual(
-      ruby.supportsYjit,
-      false,
-      "Expected YJIT support to be enabled"
-    );
-    assert.strictEqual(
-      ruby.env.BUNDLE_GEMFILE,
-      undefined,
-      "Expected BUNDLE_GEMFILE to not be set for the ruby-lsp folder"
-    );
-    assert.strictEqual(ruby.env.BUNDLE_PATH__SYSTEM, undefined);
   });
 });


### PR DESCRIPTION
I dig deeper to figure out why CI keeps failing on #507. The reason is because now that we try to execute Ruby, we're doing so with a fake system path, which we pass to `asyncExec` and then fails. Unfortunately the test output doesn't hint at that, so it wasn't clear what the issue was.

We can only use paths that exist in this test. And we unfortunately can't create paths because the file system is read only while running tests. So this PR uses the real process PWD to run the main test and simply removes the alternative one.