### PR TITLE
Add formatter status item

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,13 @@ vscode.commands.registerCommand(
 );
 ```
 
+## Formatting
+
+When `rubyLsp.formatter` is set to `auto`, Ruby LSP tries to determine which formatter to use.
+
+If the bundle has a **direct** dependency on a supported formatter, such as `rubocop` or `syntax_tree`, that will be used.
+Otherwise, formatting will be disabled and you will need add one to the bundle.
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/Shopify/vscode-ruby-lsp.

--- a/src/status.ts
+++ b/src/status.ts
@@ -20,6 +20,7 @@ export enum Command {
   ToggleYjit = "rubyLsp.toggleYjit",
   SelectVersionManager = "rubyLsp.selectRubyVersionManager",
   ToggleFeatures = "rubyLsp.toggleFeatures",
+  FormatterHelp = "rubyLsp.formatterHelp",
   RunTest = "rubyLsp.runTest",
   DebugTest = "rubyLsp.debugTest",
 }
@@ -38,6 +39,7 @@ export interface ClientInterface {
   context: vscode.ExtensionContext;
   ruby: Ruby;
   state: ServerState;
+  formatter: string;
 }
 
 export abstract class StatusItem {
@@ -340,6 +342,35 @@ export class FeaturesStatus extends StatusItem {
   }
 }
 
+export class FormatterStatus extends StatusItem {
+  constructor(client: ClientInterface) {
+    super("formatter", client);
+
+    this.item.name = "Formatter";
+    this.item.command = {
+      title: "Help",
+      command: Command.FormatterHelp,
+    };
+    this.refresh();
+  }
+
+  refresh(): void {
+    this.item.text = `Using formatter: ${this.client.formatter}`;
+  }
+
+  registerCommand(): void {
+    this.context.subscriptions.push(
+      vscode.commands.registerCommand(Command.FormatterHelp, () => {
+        vscode.env.openExternal(
+          vscode.Uri.parse(
+            "https://github.com/Shopify/vscode-ruby-lsp#formatting"
+          )
+        );
+      })
+    );
+  }
+}
+
 export class StatusItems {
   private items: StatusItem[] = [];
 
@@ -350,6 +381,7 @@ export class StatusItems {
       new ExperimentalFeaturesStatus(client),
       new YjitStatus(client),
       new FeaturesStatus(client),
+      new FormatterStatus(client),
     ];
   }
 

--- a/src/test/suite/status.test.ts
+++ b/src/test/suite/status.test.ts
@@ -14,6 +14,7 @@ import {
   ServerState,
   ClientInterface,
   FeaturesStatus,
+  FormatterStatus,
 } from "../../status";
 
 suite("StatusItems", () => {
@@ -21,6 +22,7 @@ suite("StatusItems", () => {
   let context: vscode.ExtensionContext;
   let status: StatusItem;
   let client: ClientInterface;
+  let formatter: string;
 
   beforeEach(() => {
     context = { subscriptions: [] } as unknown as vscode.ExtensionContext;
@@ -40,6 +42,7 @@ suite("StatusItems", () => {
         context,
         ruby,
         state: ServerState.Running,
+        formatter: "none",
       };
       status = new RubyVersionStatus(client);
     });
@@ -67,7 +70,7 @@ suite("StatusItems", () => {
   suite("ServerStatus", () => {
     beforeEach(() => {
       ruby = {} as Ruby;
-      client = { context, ruby, state: ServerState.Running };
+      client = { context, ruby, state: ServerState.Running, formatter: "none" };
       status = new ServerStatus(client);
     });
 
@@ -130,6 +133,7 @@ suite("StatusItems", () => {
       client = {
         context,
         ruby,
+        formatter,
         state: ServerState.Running,
       };
       status = new ExperimentalFeaturesStatus(client);
@@ -150,7 +154,7 @@ suite("StatusItems", () => {
   suite("YjitStatus when Ruby supports it", () => {
     beforeEach(() => {
       ruby = { supportsYjit: true } as Ruby;
-      client = { context, ruby, state: ServerState.Running };
+      client = { context, ruby, state: ServerState.Running, formatter: "none" };
       status = new YjitStatus(client);
     });
 
@@ -174,7 +178,7 @@ suite("StatusItems", () => {
   suite("YjitStatus when Ruby does not support it", () => {
     beforeEach(() => {
       ruby = { supportsYjit: false } as Ruby;
-      client = { context, ruby, state: ServerState.Running };
+      client = { context, ruby, state: ServerState.Running, formatter: "none" };
       status = new YjitStatus(client);
     });
 
@@ -206,6 +210,7 @@ suite("StatusItems", () => {
       status = new FeaturesStatus({
         context,
         ruby,
+        formatter,
         state: ServerState.Running,
       });
     });
@@ -251,6 +256,27 @@ suite("StatusItems", () => {
             }/${numberOfFeatures} features enabled`
           );
         });
+    });
+  });
+
+  suite("FormatterStatus", () => {
+    beforeEach(() => {
+      ruby = {} as Ruby;
+      client = {
+        context,
+        ruby,
+        state: ServerState.Running,
+        formatter: "auto",
+      };
+      status = new FormatterStatus(client);
+    });
+
+    test("Status is initialized with the right values", async () => {
+      assert.strictEqual(status.item.text, "Using formatter: auto");
+      assert.strictEqual(status.item.name, "Formatter");
+      assert.strictEqual(status.item.command?.title, "Help");
+      assert.strictEqual(status.item.command?.command, Command.FormatterHelp);
+      assert.strictEqual(context.subscriptions.length, 1);
     });
   });
 });


### PR DESCRIPTION
This PR adds a new status item to indicate to indicate which formatter is in use when `"rubyLsp.formatter": "auto"` is set.

It does this by checking for a **direct** dependency on RuboCop, or on Syntax Tree.

To support RuboCop-based gems such as `rubocop-shopify`, it checks for any gems beginning `rubocop-`.

The behaviour is intend to mirror the client-side behaviour being implemented in https://github.com/Shopify/ruby-lsp/pull/654. This essentially means we have the same behaviour duplicated across the gem and the extension. (We could not find a good way to have the behaviour only in a single place).

For consistency, we should aim to launch this ~at the same time as~ after [#614](https://github.com/Shopify/ruby-lsp/pull/654).
