### PR TITLE
Add test controller implementation

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,16 +4,24 @@ import Client from "./client";
 import { Telemetry } from "./telemetry";
 import { Ruby } from "./ruby";
 import { Debugger } from "./debugger";
+import { TestController } from "./testController";
 
 let client: Client;
 let debug: Debugger;
+let testController: TestController;
 
 export async function activate(context: vscode.ExtensionContext) {
   const ruby = new Ruby(context);
   await ruby.activateRuby();
 
   const telemetry = new Telemetry(context);
-  client = new Client(context, telemetry, ruby);
+  testController = new TestController(
+    context,
+    vscode.workspace.workspaceFolders![0].uri.fsPath,
+    ruby
+  );
+
+  client = new Client(context, telemetry, ruby, testController);
 
   await client.start();
   debug = new Debugger(context, ruby);
@@ -22,10 +30,10 @@ export async function activate(context: vscode.ExtensionContext) {
 export async function deactivate(): Promise<void> {
   if (client) {
     await client.stop();
-<<<<<<< HEAD
-=======
-    client.dispose();
->>>>>>> 2499083 (Add test controller)
+  }
+
+  if (testController) {
+    testController.dispose();
   }
 
   if (debug) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,6 +22,10 @@ export async function activate(context: vscode.ExtensionContext) {
 export async function deactivate(): Promise<void> {
   if (client) {
     await client.stop();
+<<<<<<< HEAD
+=======
+    client.dispose();
+>>>>>>> 2499083 (Add test controller)
   }
 
   if (debug) {

--- a/src/testController.ts
+++ b/src/testController.ts
@@ -1,0 +1,185 @@
+import { exec } from "child_process";
+import { promisify } from "util";
+
+import * as vscode from "vscode";
+import { CodeLens } from "vscode-languageclient/node";
+
+import { Ruby } from "./ruby";
+import { Command } from "./status";
+
+const asyncExec = promisify(exec);
+
+export class TestController {
+  private testController: vscode.TestController;
+  private testRunProfile: vscode.TestRunProfile;
+  private workingFolder: string;
+  private ruby: Ruby;
+
+  constructor(
+    context: vscode.ExtensionContext,
+    workingFolder: string,
+    ruby: Ruby
+  ) {
+    this.workingFolder = workingFolder;
+    this.ruby = ruby;
+
+    this.testController = vscode.tests.createTestController(
+      "rubyTests",
+      "Ruby Tests"
+    );
+
+    this.testRunProfile = this.testController.createRunProfile(
+      "Run",
+      vscode.TestRunProfileKind.Run,
+      (request, token) => {
+        this.runHandler(request, token);
+      },
+      true
+    );
+
+    context.subscriptions.push(
+      this.testController,
+      vscode.commands.registerCommand(
+        Command.RunTest,
+        (_path, name, _command) => {
+          this.runOnClick(name);
+        }
+      )
+    );
+  }
+
+  createTestItems(response: CodeLens[]) {
+    this.testController.items.forEach((test) => {
+      this.testController.items.delete(test.id);
+    });
+
+    let classTest: vscode.TestItem;
+    const uri = vscode.Uri.from({
+      scheme: "file",
+      path: response[0].command!.arguments![0],
+    });
+
+    response.forEach((res) => {
+      if (res.data.type === "test") {
+        const [_, name, command, location] = res.command!.arguments!;
+        const testItem: vscode.TestItem = this.testController.createTestItem(
+          name,
+          name,
+          uri
+        );
+
+        testItem.description = command;
+        testItem.range = new vscode.Range(
+          new vscode.Position(location.start_line, location.start_column),
+          new vscode.Position(location.end_line, location.end_column)
+        );
+
+        // Add test methods as children to the test class so it appears nested in Test explorer
+        // and running the test class will run all of the test methods
+        if (name.startsWith("test_")) {
+          classTest.children.add(testItem);
+        } else {
+          classTest = testItem;
+          classTest.canResolveChildren = true;
+          this.testController.items.add(testItem);
+        }
+      }
+    });
+  }
+
+  async runHandler(
+    request: vscode.TestRunRequest,
+    token: vscode.CancellationToken
+  ) {
+    const run = this.testController.createTestRun(request, undefined, false);
+    const queue: vscode.TestItem[] = [];
+
+    if (request.include) {
+      request.include.forEach((test) => queue.push(test));
+    } else {
+      this.testController.items.forEach((test) => queue.push(test));
+    }
+
+    while (queue.length > 0 && !token.isCancellationRequested) {
+      const test = queue.pop()!;
+
+      if (request.exclude?.includes(test)) {
+        continue;
+      }
+
+      const start = Date.now();
+      try {
+        await this.assertTestPasses(test);
+        run.passed(test, Date.now() - start);
+      } catch (err: any) {
+        run.failed(
+          test,
+          new vscode.TestMessage(err.message),
+          Date.now() - start
+        );
+      }
+
+      test.children.forEach((test) => queue.push(test));
+    }
+
+    // Make sure to end the run after all tests have been executed
+    run.end();
+  }
+
+  async assertTestPasses(test: vscode.TestItem) {
+    try {
+      await asyncExec(test.description!, {
+        cwd: this.workingFolder,
+        env: this.ruby.env,
+      });
+    } catch (error: any) {
+      const errorArr = error.stdout.split("\n");
+
+      if (errorArr[0] === "") {
+        // Minitest
+        throw new Error(errorArr.slice(10, errorArr.length - 2).join("\n"));
+      } else {
+        // test-unit
+        throw new Error(errorArr.slice(4, errorArr.length - 9).join("\n"));
+      }
+    }
+  }
+
+  async runOnClick(testId: string) {
+    const test = this.findTestById(this.testController.items, testId);
+
+    if (!test) return;
+
+    vscode.commands.executeCommand("vscode.revealTestInExplorer", test);
+    let tokenSource: vscode.CancellationTokenSource | null =
+      new vscode.CancellationTokenSource();
+
+    tokenSource.token.onCancellationRequested(() => {
+      tokenSource?.dispose();
+      tokenSource = null;
+
+      vscode.window.showInformationMessage("Cancelled the progress");
+    });
+
+    const testRun = new vscode.TestRunRequest([test]);
+    this.runHandler(testRun, tokenSource.token);
+  }
+
+  findTestById(testItems: vscode.TestItemCollection, testId: string) {
+    let testItem = testItems.get(testId);
+
+    if (testItem) return testItem;
+
+    testItems.forEach((test) => {
+      const childTestItem = this.findTestById(test.children, testId);
+      if (childTestItem) testItem = childTestItem;
+    });
+
+    return testItem;
+  }
+
+  dispose() {
+    this.testRunProfile.dispose();
+    this.testController.dispose();
+  }
+}

--- a/src/testController.ts
+++ b/src/testController.ts
@@ -66,30 +66,28 @@ export class TestController {
     });
 
     response.forEach((res) => {
-      if (res.data.type === "test") {
-        const [_, name, command, location] = res.command!.arguments!;
-        const testItem: vscode.TestItem = this.testController.createTestItem(
-          name,
-          name,
-          uri
-        );
+      const [_, name, command, location] = res.command!.arguments!;
+      const testItem: vscode.TestItem = this.testController.createTestItem(
+        name,
+        name,
+        uri
+      );
 
-        this.testCommands.set(testItem, command);
+      this.testCommands.set(testItem, command);
 
-        testItem.range = new vscode.Range(
-          new vscode.Position(location.start_line, location.start_column),
-          new vscode.Position(location.end_line, location.end_column)
-        );
+      testItem.range = new vscode.Range(
+        new vscode.Position(location.start_line, location.start_column),
+        new vscode.Position(location.end_line, location.end_column)
+      );
 
-        // Add test methods as children to the test class so it appears nested in Test explorer
-        // and running the test class will run all of the test methods
-        if (name.startsWith("test_")) {
-          classTest.children.add(testItem);
-        } else {
-          classTest = testItem;
-          classTest.canResolveChildren = true;
-          this.testController.items.add(testItem);
-        }
+      // Add test methods as children to the test class so it appears nested in Test explorer
+      // and running the test class will run all of the test methods
+      if (name.startsWith("test_")) {
+        classTest.children.add(testItem);
+      } else {
+        classTest = testItem;
+        classTest.canResolveChildren = true;
+        this.testController.items.add(testItem);
       }
     });
   }


### PR DESCRIPTION
### Motivation

Closes #498 
Closes #382

<img width="599" alt="Screenshot 2023-04-14 at 2 07 41 PM" src="https://user-images.githubusercontent.com/38566184/232123449-80de2463-67ac-4036-8aae-be6f4f38d4a7.png">

A continuation of #506 to use the VS Code Test Explorer 

Update: After talking with Vini, we decided not to implement opening the terminal on run and outputting the test results.

### Implementation

- Created a new class `TestController`
- Added middleware to create a VS Code [`TestItem`](https://code.visualstudio.com/api/references/vscode-api#TestItem) for each test in an open file.
- The test items are added to a [`TestController`](https://code.visualstudio.com/api/references/vscode-api#TestController) which is the entry point to discover and execute tests.
- When you either run the test from the gutter of the file editor tab or from the Test Explorer tab, executes the method `runHandler` using the [`TestRunProfile`](https://code.visualstudio.com/api/references/vscode-api#TestRunProfile).
- Updated the method registered as `rubyLsp.runTest` to `runOnClick` which finds the `TestItem` associated with the name of the test, opens the Test Explorer to display that item, and runs the test using the `runHandler` method.

### Manual Tests

1. Debug this branch on `ruby-lsp`
2. Open up a test file (ex. `test/document_test.rb`)
3. Observe there is a "Run" button next to the class definition and test method definitions
4. Open the Test Explorer tab, observe the class and test methods are runnable there
5. Click the "Run" button next to a test method; obverse that it passes
7. Click the "Run" button in the Test Explorer for the class; observe that all the tests are run and pass
8. Change one of the tests so that it will fail
9. Click the "Run" text above the method definition; obverse that it fails and that a failure message appears