### PR TITLE
Avoid using shell when undefined

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -523,6 +523,7 @@ export default class Client implements ClientInterface {
       this.outputChannel.appendLine(">> Running `bundle install`...");
 
       const install = spawn("bundle", ["install"], {
+        shell: true,
         cwd: this.workingFolder,
         signal: abortController.signal,
         env,

--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -136,10 +136,10 @@ export class Ruby {
   }
 
   private async activate(ruby: string) {
-    const result = await asyncExec(
-      `${this.shell} -ic '${ruby} --disable-gems -rjson -e "printf(%{RUBY_ENV_ACTIVATE%sRUBY_ENV_ACTIVATE}, JSON.dump(ENV.to_h))"'`,
-      { cwd: this.workingFolder }
-    );
+    let command = this.shell ? `${this.shell} -ic ` : "";
+    command += `'${ruby} --disable-gems -rjson -e "printf(%{RUBY_ENV_ACTIVATE%sRUBY_ENV_ACTIVATE}, JSON.dump(ENV.to_h))"'`;
+
+    const result = await asyncExec(command, { cwd: this.workingFolder });
 
     const envJson = result.stdout.match(
       /RUBY_ENV_ACTIVATE(.*)RUBY_ENV_ACTIVATE/
@@ -284,7 +284,9 @@ export class Ruby {
 
   private async toolExists(tool: string) {
     try {
-      await asyncExec(`${this.shell} -lic '${tool} --version'`);
+      let command = this.shell ? `${this.shell} -ic ` : "";
+      command += `'${tool} --version'`;
+      await asyncExec(command, { cwd: this.workingFolder });
       return true;
     } catch {
       return false;


### PR DESCRIPTION
### Motivation

Possibly addresses #546, #538 and #517

There are a few things addressed in this PR:
1. When removing the login flag from shell operations, we forgot to remove it when checking if tools exist
2. When running shell operations in Linux/Macos, we want to use `shell -ic` to automatically load `.bashrc` or `.zshrc`. However, this does not work on Windows
3. When we spawn for bundle install, we also need to indicate that we want to use the shell

Based on the discussions, I believe this will fix behaviour on Windows.

### Implementation

1. Remove the `-l` flag, which is not necessary (I believe this could fix #538)
2. Added `shell: true` when spawning bundle install. This shouldn't make a difference for Linux/Macos, but seems to help Windows based on the discussions
3. Stopped adding `SHELL -ic` to commands if `SHELL` is not defined (which seems to be the case on Windows)