### PR TITLE
Fix debug client launch

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,10 +21,10 @@ export async function activate(context: vscode.ExtensionContext) {
 
 export async function deactivate(): Promise<void> {
   if (client) {
-    return client.stop();
+    await client.stop();
   }
 
   if (debug) {
-    return debug.dispose();
+    debug.dispose();
   }
 }

--- a/src/test/suite/debugger.test.ts
+++ b/src/test/suite/debugger.test.ts
@@ -19,7 +19,6 @@ suite("Debugger", () => {
           request: "launch",
           // eslint-disable-next-line no-template-curly-in-string
           program: "ruby ${file}",
-          env: ruby.env,
         },
         {
           type: "ruby_lsp",
@@ -27,13 +26,11 @@ suite("Debugger", () => {
           request: "launch",
           // eslint-disable-next-line no-template-curly-in-string
           program: "ruby -Itest ${relativeFile}",
-          env: ruby.env,
         },
         {
           type: "ruby_lsp",
           name: "Debug",
           request: "attach",
-          env: ruby.env,
         },
       ],
       configs


### PR DESCRIPTION
### Motivation

There were a few issues with the debugger client that are fixed in this PR.

### Implementation

1. The `provideDebugConfigurations` method is used to create a `launch.json` file. We shouldn't inject the Ruby environment there since it shouldn't be hard coded
2. We were missing the `wait for debugger connection` message. What happened is that when that message came in, we concatenated it into `initialMessage`, but then never resolve the promise until we received another message in `stderr`, which doesn't always happen. I changed to use an `initialized` flag so that we know when to concatenate
3. We were not adding 1 to the socket file name
4. We were incorrectly returning early from `deactivate` and not disposing of the debug client properly