### PR TITLE
doc(readme): use bug template on troubleshooting section

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ BUNDLE_GEMFILE=/path/to/your/project/.ruby-lsp/Gemfile bundle install
 ```
 
 If after these steps the Ruby LSP is still not initializing properly, please report the issue
-[here](https://github.com/Shopify/vscode-ruby-lsp/issues/new?assignees=&labels=bug&template=bug_template.yml).
+[here](https://github.com/Shopify/vscode-ruby-lsp/issues/new?labels=bug&template=bug_template.yml).
 
 ## Migrating from bundle
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ BUNDLE_GEMFILE=/path/to/your/project/.ruby-lsp/Gemfile bundle install
 ```
 
 If after these steps the Ruby LSP is still not initializing properly, please report the issue
-[here](https://github.com/Shopify/vscode-ruby-lsp/issues/new).
+[here](https://github.com/Shopify/vscode-ruby-lsp/issues/new?assignees=&labels=bug&template=bug_template.yml).
 
 ## Migrating from bundle
 


### PR DESCRIPTION
### Motivation

Well, I used the previous link to create my issue: https://github.com/Shopify/vscode-ruby-lsp/issues/573

After that, I saw that another issue was using a specific template... 😕 

PS: You can decline this PR if not relevant, maybe it can avoid other reporter mistakes or maybe I'm just not attentive enough 😄 

### Implementation

Just change from the previous https://github.com/Shopify/vscode-ruby-lsp/issues/new
To the new link provided when the user picks the Ruby LSP bug template.

### Automated Tests

Not relevant

### Manual Tests

You can test the link directly [here](https://github.com/Shopify/vscode-ruby-lsp/blob/41e2986273daec1dc53bc83b42be4d3beb46403f/README.md#troubleshooting)