### PR TITLE
Add custom Ruby activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ by clicking `Change version manager` in the language status center or by changin
 // Available options are
 // "auto" (select version manager automatically)
 // "none" (do not use a version manager)
+// "custom" (use rubyLsp.customRubyCommand for finding/activating Ruby)
 // "asdf"
 // "chruby"
 // "rbenv"
@@ -57,6 +58,28 @@ by clicking `Change version manager` in the language status center or by changin
 To make sure that the Ruby LSP can find the version manager scripts, make sure that they are loaded in the shell's
 configuration script (e.g.: ~/.bashrc, ~/.zshrc) and that the SHELL environment variable is set and pointing to the
 default shell.
+
+##### Custom activation
+
+If you're using a different version manager than the ones listed above or if you're manually inserting the Ruby
+executable into the PATH, you will probably need to define custom activation so that the extension can find the correct
+Ruby.
+
+For these cases, set `rubyLsp.rubyVersionManager` to `"custom"` and then set `rubyLsp.customRubyCommand` to a shell
+command that will activate the right Ruby version or simply add the Ruby bin folder to the PATH. Some examples:
+
+```jsonc
+{
+  // Don't forget to set the manager to custom when using this option
+  "rubyLsp.rubyVersionManager": "custom",
+
+  // Using a different version manager than the ones included by default
+  "rubyLsp.customRubyCommand": "my_custom_version_manager activate",
+
+  // Adding a custom Ruby bin folder to the PATH
+  "rubyLsp.customRubyCommand": "PATH=/path/to/ruby/bin:$PATH"
+}
+```
 
 #### Configuring a formatter
 

--- a/package.json
+++ b/package.json
@@ -151,9 +151,14 @@
             "none",
             "rbenv",
             "rvm",
-            "shadowenv"
+            "shadowenv",
+            "custom"
           ],
           "default": "auto"
+        },
+        "rubyLsp.customRubyCommand": {
+          "description": "A shell command to activate the right Ruby version or add a custom Ruby bin folder to the PATH. Only used if rubyVersionManager is set to 'custom'",
+          "type": "string"
         },
         "rubyLsp.yjit": {
           "description": "Use YJIT to speed up the Ruby LSP server",

--- a/src/client.ts
+++ b/src/client.ts
@@ -399,16 +399,17 @@ export default class Client implements ClientInterface {
 
   private async projectHasDependency(gemName: string): Promise<boolean> {
     try {
+      // We can't include `BUNDLE_GEMFILE` here, because we want to check if the project's bundle includes the
+      // dependency and not our custom bundle
+      const { BUNDLE_GEMFILE, ...withoutBundleGemfileEnv } = this.ruby.env;
+
       // exit with an error if gemName not a dependency or is a transitive dependency.
       // exit with success if gemName is a direct dependency.
       await asyncExec(
-        `BUNDLE_GEMFILE=${path.join(
-          this.workingFolder,
-          "Gemfile"
-        )} bundle exec ruby -e "exit 1 unless Bundler.locked_gems.dependencies.key?('${gemName}')"`,
+        `ruby -rbundler -e "exit 1 unless Bundler.locked_gems.dependencies.key?('${gemName}')"`,
         {
           cwd: this.workingFolder,
-          env: this.ruby.env,
+          env: withoutBundleGemfileEnv,
         }
       );
       return true;

--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -15,6 +15,7 @@ export enum VersionManager {
   Rvm = "rvm",
   Shadowenv = "shadowenv",
   None = "none",
+  Custom = "custom",
 }
 
 export class Ruby {
@@ -78,6 +79,9 @@ export class Ruby {
           break;
         case VersionManager.Rvm:
           await this.activate("rvm-auto-ruby");
+          break;
+        case VersionManager.Custom:
+          await this.activateCustomRuby();
           break;
         case VersionManager.None:
           await this.activate("ruby");
@@ -297,5 +301,20 @@ export class Ruby {
     return new Promise((resolve) => {
       setTimeout(resolve, mseconds);
     });
+  }
+
+  private async activateCustomRuby() {
+    const configuration = vscode.workspace.getConfiguration("rubyLsp");
+    const customCommand: string | undefined =
+      configuration.get("customRubyCommand");
+
+    if (customCommand === undefined) {
+      throw new Error(
+        "The customRubyCommand configuration must be set when 'custom' is selected as the version manager. \
+        See the [README](https://github.com/Shopify/vscode-ruby-lsp#custom-activation) for instructions."
+      );
+    }
+
+    await this.activate(`${customCommand} && ruby`);
   }
 }


### PR DESCRIPTION
### Motivation

Closes Shopify/ruby-lsp#1571
Closes Shopify/ruby-lsp#1577

We need to provide a way for custom Ruby activation for less common version managers or installers that don't activate the Ruby environment, such as the ones on Windows.

This PR adds a new configuration that can be used to define the custom activation and also fixes the bug in Shopify/ruby-lsp#1577. Testing these changes surfaced the issue in my editor and I managed to find what I believe is the root cause.

### Implementation

- Added a new section in the README to explain the custom activation
- Added a new configuration for the custom activation
- In `Ruby`, added a new version manager option and start executing the configured custom command before invoking ruby


Finally, I changed the way `projectHasDependency` is implemented a bit. There are two fixes included
1. We shouldn't use `BUNDLE_GEMFILE` when checking if a project has a dependency. We're interested in knowing if the main bundle has the dependency - not our custom bundle. So we can't include `BUNDLE_GEMFILE` or else we're basically asking if our own `Gemfile` includes the dependency
2. For some reason, using `bundle exec ruby` always seems to load an incorrect bundle. Removing `bundle exec` and just requiring bundler makes the check work properly