### PR TITLE
Support debugging tests with code lens

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -264,7 +264,11 @@ export default class Client implements ClientInterface {
         Command.Update,
         this.updateServer.bind(this)
       ),
-      vscode.commands.registerCommand(Command.RunTest, this.runTest.bind(this))
+      vscode.commands.registerCommand(Command.RunTest, this.runTest.bind(this)),
+      vscode.commands.registerCommand(
+        Command.DebugTest,
+        this.debugTest.bind(this)
+      )
     );
   }
 
@@ -275,6 +279,16 @@ export default class Client implements ClientInterface {
 
     this.terminal.show();
     this.terminal.sendText(command);
+  }
+
+  private debugTest(_path: string, _name: string, command: string) {
+    return vscode.debug.startDebugging(undefined, {
+      type: "ruby_lsp",
+      name: "Debug",
+      request: "launch",
+      program: command,
+      env: this.ruby.env,
+    });
   }
 
   private async setupCustomGemfile() {

--- a/src/status.ts
+++ b/src/status.ts
@@ -21,6 +21,7 @@ export enum Command {
   SelectVersionManager = "rubyLsp.selectRubyVersionManager",
   ToggleFeatures = "rubyLsp.toggleFeatures",
   RunTest = "rubyLsp.runTest",
+  DebugTest = "rubyLsp.debugTest",
 }
 
 const STOPPED_SERVER_OPTIONS = [


### PR DESCRIPTION
### Motivation

We want to let users debug their tests with code lens with well.

### Implementation

With https://github.com/Shopify/ruby-lsp/pull/657, we can display a `Debug` code lens on top of test classes/methods. Once clicked, the tests would be run with debugger attached.

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

### Manual Tests

1. Click `Run Extension` in the debug panel
2. Make sure the `Extension Development Host` runs `ruby-lsp` and is using the `st0012-debug-test` branch
3. Open `test/document_test.rb` in `ruby-lsp`
4. Above the test class and methods, you should see 2 code lenses: `Test` and `Debug`
5. Set a breakpoint on line `14`
6. Click the `Debug` code lens above `test_valid_incremental_edits`
7. The test should be run in debug mode, and the debugger should stop at the breakpoint. Example:

    <img width="80%" alt="Screenshot 2023-04-26 at 18 25 42" src="https://user-images.githubusercontent.com/5079556/234654872-0e09db30-6c84-4c73-b043-3be1a69f89c3.png">
