### PR TITLE
Add Formatter status item (v2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,13 @@ vscode.commands.registerCommand(
 );
 ```
 
+## Formatting
+
+When `rubyLsp.formatter` is set to `auto`, Ruby LSP tries to determine which formatter to use.
+
+If the bundle has a **direct** dependency on a supported formatter, such as `rubocop` or `syntax_tree`, that will be used.
+Otherwise, formatting will be disabled and you will need add one to the bundle.
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/Shopify/vscode-ruby-lsp.

--- a/src/status.ts
+++ b/src/status.ts
@@ -20,6 +20,7 @@ export enum Command {
   ToggleYjit = "rubyLsp.toggleYjit",
   SelectVersionManager = "rubyLsp.selectRubyVersionManager",
   ToggleFeatures = "rubyLsp.toggleFeatures",
+  FormatterHelp = "rubyLsp.formatterHelp",
   RunTest = "rubyLsp.runTest",
 }
 
@@ -339,6 +340,39 @@ export class FeaturesStatus extends StatusItem {
   }
 }
 
+export class FormatterStatus extends StatusItem {
+  constructor(client: ClientInterface) {
+    super("formatter", client);
+
+    this.item.name = "Formatter";
+    this.item.command = {
+      title: "Help",
+      command: Command.FormatterHelp,
+    };
+    this.refresh();
+  }
+
+  refresh(): void {
+    const formatter: string = vscode.workspace
+      .getConfiguration("rubyLsp")
+      .get("formatter")!;
+
+    this.item.text = `Formatter: ${formatter}`;
+  }
+
+  registerCommand(): void {
+    this.context.subscriptions.push(
+      vscode.commands.registerCommand(Command.FormatterHelp, () => {
+        vscode.env.openExternal(
+          vscode.Uri.parse(
+            "https://github.com/Shopify/vscode-ruby-lsp#formatting"
+          )
+        );
+      })
+    );
+  }
+}
+
 export class StatusItems {
   private items: StatusItem[] = [];
 
@@ -349,6 +383,7 @@ export class StatusItems {
       new ExperimentalFeaturesStatus(client),
       new YjitStatus(client),
       new FeaturesStatus(client),
+      new FormatterStatus(client),
     ];
   }
 

--- a/src/test/suite/status.test.ts
+++ b/src/test/suite/status.test.ts
@@ -14,6 +14,7 @@ import {
   ServerState,
   ClientInterface,
   FeaturesStatus,
+  FormatterStatus,
 } from "../../status";
 
 suite("StatusItems", () => {
@@ -251,6 +252,26 @@ suite("StatusItems", () => {
             }/${numberOfFeatures} features enabled`
           );
         });
+    });
+  });
+
+  suite("FormatterStatus", () => {
+    beforeEach(() => {
+      ruby = {} as Ruby;
+      client = {
+        context,
+        ruby,
+        state: ServerState.Running,
+      };
+      status = new FormatterStatus(client);
+    });
+
+    test("Status is initialized with the right values", async () => {
+      assert.strictEqual(status.item.text, "Formatter: auto");
+      assert.strictEqual(status.item.name, "Formatter");
+      assert.strictEqual(status.item.command?.title, "Help");
+      assert.strictEqual(status.item.command?.command, Command.FormatterHelp);
+      assert.strictEqual(context.subscriptions.length, 1);
     });
   });
 });


### PR DESCRIPTION
To mitigate some of the potential complications in https://github.com/Shopify/vscode-ruby-lsp/pull/549/files, this is a simpler Status Item which shows only the configured `formatter` setting and does not attempt to determine the formatter which would be used.