### PR TITLE
Add `Run In Terminal` code lens

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -286,22 +286,8 @@ export default class Client implements ClientInterface {
       vscode.commands.registerCommand(
         Command.Update,
         this.updateServer.bind(this)
-      ),
-      vscode.commands.registerCommand(
-        Command.DebugTest,
-        this.debugTest.bind(this)
       )
     );
-  }
-
-  private debugTest(_path: string, _name: string, command: string) {
-    return vscode.debug.startDebugging(undefined, {
-      type: "ruby_lsp",
-      name: "Debug",
-      request: "launch",
-      program: command,
-      env: this.ruby.env,
-    });
   }
 
   private async setupCustomGemfile() {

--- a/src/status.ts
+++ b/src/status.ts
@@ -21,6 +21,7 @@ export enum Command {
   SelectVersionManager = "rubyLsp.selectRubyVersionManager",
   ToggleFeatures = "rubyLsp.toggleFeatures",
   RunTest = "rubyLsp.runTest",
+  RunTestInTerminal = "rubyLsp.runTestInTerminal",
   DebugTest = "rubyLsp.debugTest",
 }
 


### PR DESCRIPTION
### Motivation

Because the test controller isn't able to handle dynamically generated tests, the `Run` code lens is not able to run them. This means those tests are not supported by any code lens anymore, while in prior versions they could be run in the terminal.

This PR adds a new code lens `Run In Terminal` that will run the tests in the terminal.

(This requires https://github.com/Shopify/ruby-lsp/pull/686)

### Implementation

1. Add terminal handling logic back to `client.ts`
2. Add a `runTestInTerminal` function that runs the code lens command in the terminal

Result: 

<img width="780" alt="Screenshot 2023-05-02 at 23 18 11" src="https://user-images.githubusercontent.com/5079556/235797885-e92dea98-2aef-4dc6-a7b7-e0ffcde4f583.png">

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
