### PR TITLE
Remove unnecessary check for `test_` in test name

### DIFF
--- a/src/testController.ts
+++ b/src/testController.ts
@@ -16,6 +16,7 @@ export class TestController {
   private workingFolder: string;
   private terminal: vscode.Terminal | undefined;
   private ruby: Ruby;
+  private minitestTag = new vscode.TestTag("minitest");
 
   constructor(
     context: vscode.ExtensionContext,
@@ -40,7 +41,7 @@ export class TestController {
       },
       true
     );
-    this.testRunProfile.tag = new vscode.TestTag("minitest");
+    this.testRunProfile.tag = this.minitestTag;
 
     vscode.commands.executeCommand("testing.clearTestResults");
     vscode.window.onDidCloseTerminal((terminal: vscode.Terminal): void => {
@@ -145,7 +146,8 @@ export class TestController {
         continue;
       }
 
-      if (test.tags.includes(new vscode.TestTag("minitest"))) {
+      // older versions of ruby-lsp will not include the minitest tag, so we need to fall back to checking the test name.
+      if (test.tags.includes(this.minitestTag) || test.id.startsWith("test_")) {
         const start = Date.now();
         try {
           await this.assertTestPasses(test);

--- a/src/testController.ts
+++ b/src/testController.ts
@@ -142,28 +142,26 @@ export class TestController {
         continue;
       }
 
-      if (test.id.startsWith("test_")) {
-        const start = Date.now();
-        try {
-          await this.assertTestPasses(test);
-          run.passed(test, Date.now() - start);
-        } catch (err: any) {
-          const messageArr = err.message.split("\n");
+      const start = Date.now();
+      try {
+        await this.assertTestPasses(test);
+        run.passed(test, Date.now() - start);
+      } catch (err: any) {
+        const messageArr = err.message.split("\n");
 
-          // Minitest and test/unit outputs are formatted differently so we need to slice the message
-          // differently to get an output format that only contains essential information
-          // If the first element of the message array is "", we know the output is a Minitest output
-          const testMessage =
-            messageArr[0] === ""
-              ? messageArr.slice(10, messageArr.length - 2).join("\n")
-              : messageArr.slice(4, messageArr.length - 9).join("\n");
+        // Minitest and test/unit outputs are formatted differently so we need to slice the message
+        // differently to get an output format that only contains essential information
+        // If the first element of the message array is "", we know the output is a Minitest output
+        const testMessage =
+          messageArr[0] === ""
+            ? messageArr.slice(10, messageArr.length - 2).join("\n")
+            : messageArr.slice(4, messageArr.length - 9).join("\n");
 
-          run.failed(
-            test,
-            new vscode.TestMessage(testMessage),
-            Date.now() - start
-          );
-        }
+        run.failed(
+          test,
+          new vscode.TestMessage(testMessage),
+          Date.now() - start
+        );
       }
 
       test.children.forEach((test) => queue.push(test));


### PR DESCRIPTION
I recommend viewing with whitespace changes disabled:
https://github.com/Shopify/vscode-ruby-lsp/pull/604/files?w=1

### Motivation

This is to support https://github.com/Shopify/ruby-lsp-rails/pull/67

For minitest or test/unit tests, we expect the name in the form of `test_foo_does_something`. But for Rails tests, we expect the form `foo does something`.

Currently, the Test Explorer requires that the test name begins `test_` and so does not work with Rails tests.

But this check seems unnecessary. We are already checking in the gem that the test name begins with `test_`: https://github.com/Shopify/ruby-lsp/blob/main/lib/ruby_lsp/requests/code_lens.rb

<!-- Explain why you are making this change. Describe the problem being solved, not the solution. -->

### Implementation

Remove the check.

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

### Manual Tests

Open a test file and view the test explorer. Add a public method which does not begin with `test_`. Ensure it does not appear in the test explorer.
