### PR TITLE
Drop Ruby 2.7 support

### DIFF
--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -165,9 +165,9 @@ export class Ruby {
 
     const [major, minor, _patch] = this.rubyVersion.split(".").map(Number);
 
-    if ((major === 2 && minor < 7) || major < 2) {
+    if (major < 3) {
       throw new Error(
-        "The Ruby LSP requires Ruby 2.7 or newer to run. Please upgrade your Ruby version"
+        "The Ruby LSP requires Ruby 3.0 or newer to run. Please upgrade your Ruby version"
       );
     }
 


### PR DESCRIPTION
### Motivation

Following up from https://github.com/Shopify/ruby-lsp/pull/732