### PR TITLE
Support env on debug launch configurations

### DIFF
--- a/package.json
+++ b/package.json
@@ -204,6 +204,13 @@
               "program": {
                 "type": "string",
                 "description": "The program to debug"
+              },
+              "env": {
+                "type": "object",
+                "description": "Environment variables defined as a key value pair. Example: { \"BACKTRACE\": \"1\" }",
+                "additionalProperties": {
+                  "type": "string"
+                }
               }
             }
           },

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -88,8 +88,16 @@ export class Debugger
     debugConfiguration: vscode.DebugConfiguration,
     _token?: vscode.CancellationToken
   ): vscode.ProviderResult<vscode.DebugConfiguration> {
-    // If the user has their own debug launch configurations, we still need to inject the Ruby environment
-    debugConfiguration.env = this.ruby.env;
+    if (debugConfiguration.env) {
+      // If the user has their own debug launch configurations, we still need to inject the Ruby environment
+      debugConfiguration.env = Object.assign(
+        debugConfiguration.env,
+        this.ruby.env
+      );
+    } else {
+      debugConfiguration.env = this.ruby.env;
+    }
+
     return debugConfiguration;
   }
 
@@ -140,6 +148,7 @@ export class Debugger
     let initialMessage = "";
     let initialized = false;
     const sockPath = this.socketPath();
+    const configuration = session.configuration;
 
     return new Promise((resolve, reject) => {
       this.debugProcess = spawn(
@@ -151,11 +160,11 @@ export class Debugger
           "--command",
           `--sock-path=${sockPath}`,
           "--",
-          session.configuration.program,
+          configuration.program,
         ],
         {
           shell: true,
-          env: this.ruby.env,
+          env: configuration.env,
           cwd: this.workingFolder,
         }
       );

--- a/src/test/suite/debugger.test.ts
+++ b/src/test/suite/debugger.test.ts
@@ -54,4 +54,21 @@ suite("Debugger", () => {
     assert.strictEqual(ruby.env, configs.env);
     debug.dispose();
   });
+
+  test("Resolve configuration injects Ruby environment and allows users custom environment", () => {
+    const context = { subscriptions: [] } as unknown as vscode.ExtensionContext;
+    const ruby = { env: { bogus: "hello!" } } as unknown as Ruby;
+    const debug = new Debugger(context, ruby, "fake");
+    const configs: any = debug.resolveDebugConfiguration!(undefined, {
+      type: "ruby_lsp",
+      name: "Debug",
+      request: "launch",
+      // eslint-disable-next-line no-template-curly-in-string
+      program: "ruby ${file}",
+      env: { parallel: "1" },
+    });
+
+    assert.deepEqual({ parallel: "1", ...ruby.env }, configs.env);
+    debug.dispose();
+  });
 });


### PR DESCRIPTION
### Motivation

In the Rails project we need to pass an environment variable to disable parallel running of the tests. This commit adds support to set this configuration in the debug launch configuration instead of requiring the user to change the test runner script.

Fixes #630.
