### PR TITLE
Send configuration telemetry

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,6 +15,8 @@ export async function activate(context: vscode.ExtensionContext) {
   await ruby.activateRuby();
 
   const telemetry = new Telemetry(context);
+  await telemetry.sendConfigurationEvents();
+
   testController = new TestController(
     context,
     vscode.workspace.workspaceFolders![0].uri.fsPath,

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -1,6 +1,6 @@
 import * as vscode from "vscode";
 
-export interface TelemetryEvent {
+interface RequestEvent {
   request: string;
   requestTime: number;
   lspVersion: string;
@@ -12,6 +12,16 @@ export interface TelemetryEvent {
   rubyVersion: string;
   yjitEnabled: boolean;
 }
+
+export interface ConfigurationEvent {
+  namespace: string;
+  field: string;
+  value: string;
+}
+
+export type TelemetryEvent = RequestEvent | ConfigurationEvent;
+
+const ONE_DAY_IN_MS = 24 * 60 * 60 * 1000;
 
 export interface TelemetryApi {
   sendEvent(event: TelemetryEvent): Promise<void>;
@@ -26,8 +36,11 @@ class DevelopmentApi implements TelemetryApi {
 
 export class Telemetry {
   private api?: TelemetryApi;
+  private context: vscode.ExtensionContext;
 
   constructor(context: vscode.ExtensionContext, api?: TelemetryApi) {
+    this.context = context;
+
     if (context.extensionMode === vscode.ExtensionMode.Development && !api) {
       this.api = new DevelopmentApi();
     } else {
@@ -37,8 +50,57 @@ export class Telemetry {
 
   async sendEvent(event: TelemetryEvent) {
     if (await this.initialize()) {
-      return this.api!.sendEvent(event);
+      this.api!.sendEvent(event);
     }
+  }
+
+  async sendConfigurationEvents() {
+    const lastConfigurationTelemetry: number | undefined =
+      this.context.globalState.get("rubyLsp.lastConfigurationTelemetry");
+
+    if (
+      lastConfigurationTelemetry &&
+      Date.now() - lastConfigurationTelemetry <= ONE_DAY_IN_MS
+    ) {
+      return;
+    }
+
+    const promises: Promise<void>[] = [
+      { namespace: "workbench", field: "colorTheme" },
+      { namespace: "rubyLsp", field: "enableExperimentalFeatures" },
+      { namespace: "rubyLsp", field: "yjit" },
+      { namespace: "rubyLsp", field: "rubyVersionManager" },
+      { namespace: "rubyLsp", field: "formatter" },
+    ].map(({ namespace, field }) => {
+      return this.sendEvent({
+        namespace,
+        field,
+        value: (
+          vscode.workspace.getConfiguration(namespace).get(field) ?? ""
+        ).toString(),
+      });
+    });
+
+    const enabledFeatures = vscode.workspace
+      .getConfiguration("rubyLsp")
+      .get("enabledFeatures")!;
+
+    Object.entries(enabledFeatures).forEach(([field, value]) => {
+      promises.push(
+        this.sendEvent({
+          namespace: "rubyLsp.enabledFeatures",
+          field,
+          value: value.toString(),
+        })
+      );
+    });
+
+    await Promise.all(promises);
+
+    this.context.globalState.update(
+      "rubyLsp.lastConfigurationTelemetry",
+      Date.now()
+    );
   }
 
   private async initialize(): Promise<boolean> {


### PR DESCRIPTION
### Motivation

Send configuration telemetry to the private metrics extension on activation. The idea is to capture configuration related to the Ruby LSP once a day, so that we can understand how people are using it.

### Implementation

1. Added a new method `sendConfigurationEvents` to `Telemetry`, which reads all configurations we list and sends it to the private extension. The method only does it once a day
2. Started invoking the method on activation

### Automated Tests

Added a test to verify that the events are being sent.