### PR TITLE
Send code lens telemetry

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,7 +20,8 @@ export async function activate(context: vscode.ExtensionContext) {
   testController = new TestController(
     context,
     vscode.workspace.workspaceFolders![0].uri.fsPath,
-    ruby
+    ruby,
+    telemetry
   );
 
   client = new Client(context, telemetry, ruby, testController);

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -19,7 +19,12 @@ export interface ConfigurationEvent {
   value: string;
 }
 
-export type TelemetryEvent = RequestEvent | ConfigurationEvent;
+export interface CodeLensEvent {
+  type: "test" | "debug" | "test_in_terminal" | "link";
+  lspVersion: string;
+}
+
+export type TelemetryEvent = RequestEvent | ConfigurationEvent | CodeLensEvent;
 
 const ONE_DAY_IN_MS = 24 * 60 * 60 * 1000;
 
@@ -35,6 +40,7 @@ class DevelopmentApi implements TelemetryApi {
 }
 
 export class Telemetry {
+  public serverVersion?: string;
   private api?: TelemetryApi;
   private context: vscode.ExtensionContext;
 
@@ -101,6 +107,10 @@ export class Telemetry {
       "rubyLsp.lastConfigurationTelemetry",
       Date.now()
     );
+  }
+
+  async sendCodeLensEvent(type: CodeLensEvent["type"]) {
+    await this.sendEvent({ type, lspVersion: this.serverVersion! });
   }
 
   private async initialize(): Promise<boolean> {

--- a/src/test/suite/telemetry.test.ts
+++ b/src/test/suite/telemetry.test.ts
@@ -7,6 +7,7 @@ import {
   TelemetryApi,
   TelemetryEvent,
   ConfigurationEvent,
+  CodeLensEvent,
 } from "../../telemetry";
 
 class FakeApi implements TelemetryApi {
@@ -97,5 +98,26 @@ suite("Telemetry", () => {
     api.sentEvents.forEach((event) => {
       assert.strictEqual(typeof (event as ConfigurationEvent).value, "string");
     });
+  });
+
+  test("Send code lens event includes configured server version", async () => {
+    const api = new FakeApi();
+    const telemetry = new Telemetry(
+      {
+        extensionMode: vscode.ExtensionMode.Production,
+        globalState: {
+          get: () => undefined,
+          update: () => Promise.resolve(),
+        } as unknown,
+      } as vscode.ExtensionContext,
+      api
+    );
+
+    telemetry.serverVersion = "1.0.0";
+    await telemetry.sendCodeLensEvent("test");
+
+    const codeLensEvent = api.sentEvents[0] as CodeLensEvent;
+    assert.strictEqual(codeLensEvent.type, "test");
+    assert.strictEqual(codeLensEvent.lspVersion, "1.0.0");
   });
 });


### PR DESCRIPTION
### Motivation

Send code lens telemetry for the 4 types supported (test, debug, test_in_terminal and link).

### Implementation

I made `Client` be the thing that determines the server version and then we set that in the telemetry object. Let me know what you think about the approach.

### Automated Tests

Added a test for the new telemetry function.

### Manual Tests

1. Start the LSP on this branch
2. Click on any code lens
3. In the `Debug console` of the main window (where vscode-ruby-lsp is), verify code lens telemetry is printed