### PR TITLE
Add `customWorkspaceFolder` setting to set a custom `workingFolder`

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "activationEvents": [
     "onLanguage:ruby",
-    "workspaceContains:Gemfile.lock"
+    "workspaceContains:**/Gemfile.lock"
   ],
   "main": "./out/extension.js",
   "contributes": {
@@ -178,6 +178,11 @@
         },
         "rubyLsp.bundleGemfile": {
           "description": "Relative path to the Gemfile to use for bundling the Ruby LSP server. Only necessary when using a separate Gemfile for the Ruby LSP",
+          "type": "string",
+          "default": ""
+        },
+        "rubyLsp.customWorkspaceFolder": {
+          "description": "A custom working directory for the Ruby LSP server. Only necessary if your Gemfile isn't located at the VS Code workspace root",
           "type": "string",
           "default": ""
         }

--- a/src/client.ts
+++ b/src/client.ts
@@ -46,9 +46,10 @@ export default class Client implements ClientInterface {
     context: vscode.ExtensionContext,
     telemetry: Telemetry,
     ruby: Ruby,
-    testController: TestController
+    testController: TestController,
+    workingFolder = vscode.workspace.workspaceFolders![0].uri.fsPath
   ) {
-    this.workingFolder = vscode.workspace.workspaceFolders![0].uri.fsPath;
+    this.workingFolder = workingFolder;
     this.telemetry = telemetry;
     this.testController = testController;
     this.#context = context;


### PR DESCRIPTION
### Motivation

<!-- Closes # -->
Closes #621 

<!-- Explain why you are making this change. Describe the problem being solved, not the solution. -->
Allow opening a VS Code workspace in any folder (not only those containing a `Gemfile.lock` at the root), and have `ruby-lsp` properly run.
 > Only mandatory condition is that there is a `Gemfile.lock` in a subfolder of the VS Code workspace.

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
I added a `workingFolder` in `Client` constructor (was already present in `Ruby`, `Debugger` and `TestController`). If `customWorkspaceFolder` configuration is set, initialize all classes with it, otherwise fallback to default VSCode workspace.

> it's probably possible to extract this `workingFolder` resolution out of `extension.ts`, but I wanted to see if the approach was accepted first.

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->
This is merely at proof of concept state. I'll be happy to add some tests if the implementation is deemed relevant.

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
- I added the `customWorkspaceFolder` setting in my VS Code instance.
- I ran `yarn package` to build a VSIX file
- I installed the extension through "Install from VSIX..."

