### PR TITLE
Disable spring on debug code lens

### DIFF
--- a/src/testController.ts
+++ b/src/testController.ts
@@ -137,7 +137,7 @@ export class TestController {
       name: "Debug",
       request: "launch",
       program: command,
-      env: this.ruby.env,
+      env: { ...this.ruby.env, DISABLE_SPRING: "1" },
     });
   }
 


### PR DESCRIPTION
### Motivation

Spring can mess up functionality of the debugger, so we're better off disabling it by default on debug code lenses.

### Implementation

Included `DISABLE_SPRING: "1"` together with all of the other environment variables when debugging tests.