### PR TITLE
Prefer custom bundle when checking server version

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -623,11 +623,23 @@ export default class Client implements ClientInterface {
   }
 
   private async getServerVersion(): Promise<string> {
-    const result = await asyncExec(
-      `BUNDLE_GEMFILE=${path.join(
+    let bundleGemfile;
+
+    if (fs.existsSync(path.join(this.workingFolder, ".ruby-lsp", "Gemfile"))) {
+      bundleGemfile = `BUNDLE_GEMFILE=${path.join(
+        this.workingFolder,
+        ".ruby-lsp",
+        "Gemfile"
+      )}`;
+    } else {
+      bundleGemfile = `BUNDLE_GEMFILE=${path.join(
         this.workingFolder,
         "Gemfile"
-      )} bundle exec ruby -e "require 'ruby-lsp'; print RubyLsp::VERSION"`,
+      )}`;
+    }
+
+    const result = await asyncExec(
+      `${bundleGemfile} bundle exec ruby -e "require 'ruby-lsp'; print RubyLsp::VERSION"`,
       {
         cwd: this.workingFolder,
         env: this.ruby.env,


### PR DESCRIPTION
### Motivation

The telemetry PRs included a mistake when checking the server version. If the project doesn't have the Ruby LSP in the bundle, then the check will fail. We need to favour looking into `.ruby-lsp/Gemfile` if that exists and then fallback to the top level otherwise.