### PR TITLE
Fix fetching server version for configured bundle path

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -624,8 +624,17 @@ export default class Client implements ClientInterface {
 
   private async getServerVersion(): Promise<string> {
     let bundleGemfile;
+    const customBundleGemfile: string = vscode.workspace
+      .getConfiguration("rubyLsp")
+      .get("bundleGemfile")!;
 
-    if (fs.existsSync(path.join(this.workingFolder, ".ruby-lsp", "Gemfile"))) {
+    // If a custom Gemfile was configured outside of the project, use that. Otherwise, prefer our custom bundle over the
+    // app's bundle
+    if (customBundleGemfile.length > 0) {
+      bundleGemfile = `BUNDLE_GEMFILE=${customBundleGemfile}`;
+    } else if (
+      fs.existsSync(path.join(this.workingFolder, ".ruby-lsp", "Gemfile"))
+    ) {
       bundleGemfile = `BUNDLE_GEMFILE=${path.join(
         this.workingFolder,
         ".ruby-lsp",


### PR DESCRIPTION
### Motivation

Closes #671

If the user has configured a custom Gemfile outside of the project, then we need to use that to check the version of the server.

### Implementation

Added another check to define the correct `bundleGemfile` to use.