### PR TITLE
Show errors when working on ruby-lsp and ruby-lsp-rails

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -202,13 +202,25 @@ export default class Client implements ClientInterface {
       clientOptions
     );
 
-    this.client.onTelemetry((event) =>
-      this.telemetry.sendEvent({
-        ...event,
-        rubyVersion: this.ruby.rubyVersion,
-        yjitEnabled: this.ruby.yjitEnabled,
-      })
-    );
+    const baseFolder = path.basename(this.workingFolder);
+
+    this.client.onTelemetry((event) => {
+      // If an error occurs in the ruby-lsp or ruby-lsp-rails projects, don't send telemetry, but show an error message
+      if (
+        event.errorMessage &&
+        (baseFolder === "ruby-lsp" || baseFolder === "ruby-lsp-rails")
+      ) {
+        vscode.window.showErrorMessage(
+          `Ruby LSP error ${event.errorClass}:${event.errorMessage}`
+        );
+      } else {
+        this.telemetry.sendEvent({
+          ...event,
+          rubyVersion: this.ruby.rubyVersion,
+          yjitEnabled: this.ruby.yjitEnabled,
+        });
+      }
+    });
 
     this.telemetry.serverVersion = await this.getServerVersion();
     await this.client.start();

--- a/src/client.ts
+++ b/src/client.ts
@@ -211,7 +211,7 @@ export default class Client implements ClientInterface {
         (baseFolder === "ruby-lsp" || baseFolder === "ruby-lsp-rails")
       ) {
         vscode.window.showErrorMessage(
-          `Ruby LSP error ${event.errorClass}:${event.errorMessage}`
+          `Ruby LSP error ${event.errorClass}: ${event.errorMessage}`
         );
       } else {
         this.telemetry.sendEvent({


### PR DESCRIPTION
### Motivation

Closes #585

When working on `ruby-lsp` and `ruby-lsp-rails`, it's better to have errors surfaced straight away than sending to telemetry, so that we can see it and address it soon. This will be particularly useful for large migrations, like transitioning to YARP.

### Implementation

Started showing a dialogue if the error telemetry occurred inside of `ruby-lsp` or `ruby-lsp-rails`.