### PR TITLE
Add show syntax tree request

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,10 @@
       {
         "command": "rubyLsp.update",
         "title": "Ruby LSP: Update language server gem"
+      },
+      {
+        "command": "rubyLsp.showSyntaxTree",
+        "title": "Ruby LSP: Show syntax tree"
       }
     ],
     "configuration": {

--- a/src/documentProvider.ts
+++ b/src/documentProvider.ts
@@ -1,0 +1,19 @@
+import * as vscode from "vscode";
+
+// This document provider is used for the `ruby-lsp://` scheme to show virtual files. For example, we use it to display
+// the AST for a given Ruby file
+export default class DocumentProvider
+  implements vscode.TextDocumentContentProvider
+{
+  public provideTextDocumentContent(uri: vscode.Uri): string {
+    let response = "Not a valid Ruby LSP document";
+
+    switch (uri.path) {
+      case "show-syntax-tree":
+        response = uri.query;
+        break;
+    }
+
+    return response;
+  }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,6 +5,7 @@ import { Telemetry } from "./telemetry";
 import { Ruby } from "./ruby";
 import { Debugger } from "./debugger";
 import { TestController } from "./testController";
+import DocumentProvider from "./documentProvider";
 
 let client: Client;
 let debug: Debugger;
@@ -28,6 +29,11 @@ export async function activate(context: vscode.ExtensionContext) {
 
   await client.start();
   debug = new Debugger(context, ruby);
+
+  vscode.workspace.registerTextDocumentContentProvider(
+    "ruby-lsp",
+    new DocumentProvider()
+  );
 }
 
 export async function deactivate(): Promise<void> {

--- a/src/status.ts
+++ b/src/status.ts
@@ -25,6 +25,7 @@ export enum Command {
   RunTestInTerminal = "rubyLsp.runTestInTerminal",
   DebugTest = "rubyLsp.debugTest",
   OpenLink = "rubyLsp.openLink",
+  ShowSyntaxTree = "rubyLsp.showSyntaxTree",
 }
 
 const STOPPED_SERVER_OPTIONS = [


### PR DESCRIPTION
### Motivation

Server part https://github.com/Shopify/ruby-lsp/pull/805

Add a command to show the syntax tree of the current Ruby document.

### Implementation

The new command sends a custom request to the server to get the pretty printed AST back.

Then we use a custom `DocumentProvider` to handle a new `ruby-lsp://` URI scheme. The only reason this is needed is so that the opened file doesn't have to be saved by the user and can be closed directly.