### PR TITLE
Find run test terminal if we lose the in-memory reference

### DIFF
--- a/src/testController.ts
+++ b/src/testController.ts
@@ -10,6 +10,8 @@ import { Telemetry } from "./telemetry";
 
 const asyncExec = promisify(exec);
 
+const TERMINAL_NAME = "Ruby LSP: Run test";
+
 export class TestController {
   private testController: vscode.TestController;
   private testCommands: WeakMap<vscode.TestItem, string>;
@@ -153,10 +155,23 @@ export class TestController {
     await this.telemetry.sendCodeLensEvent("test_in_terminal");
 
     if (this.terminal === undefined) {
-      this.terminal = vscode.window.createTerminal({ name: "Run test" });
+      this.terminal = this.getTerminal();
     }
+
     this.terminal.show();
     this.terminal.sendText(command);
+  }
+
+  private getTerminal() {
+    const previousTerminal = vscode.window.terminals.find(
+      (terminal) => terminal.name === TERMINAL_NAME
+    );
+
+    return previousTerminal
+      ? previousTerminal
+      : vscode.window.createTerminal({
+          name: TERMINAL_NAME,
+        });
   }
 
   private async debugHandler(


### PR DESCRIPTION
### Motivation

We store the terminal used to run tests in the test controller state. If the VS Code window is reloaded without closing that terminal, it will still exist, but we won't use it because the reload made we lose the reference to `this.terminal`.

It's a bit annoying, so I propose we name the terminal with something quite specific and try to find any open terminals with the expected name. That way, we don't re-open an unnecessary amount of terminals.

### Implementation

Changed the name of the terminal to be `Ruby LSP: Run test` to avoid any conflicts. If we find an open terminal with that name, we store the reference again in `this.terminal` instead of opening another terminal.

### Manual Tests

1. Start the extension on this branch
2. Use one of the `Run in terminal` code lenses
3. Reload the VS Code window
4. Use one of the `Run in terminal` code lenses again
5. Verify the same terminal is reused