### PR TITLE
Add `workbench.action.terminal.runSelectedTex` command to context menu

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,15 @@
   ],
   "main": "./out/extension.js",
   "contributes": {
+    "menus": {
+      "editor/context": [
+        {
+          "when": "resourceLangId == ruby",
+          "command": "workbench.action.terminal.runSelectedText",
+          "group": "9_cutcopypaste"
+        }
+      ]
+    },
     "commands": [
       {
         "command": "rubyLsp.start",


### PR DESCRIPTION
### Motivation

This will allow users to run selected text in the terminal by right clicking on the selected text and selecting `Run Selected Text in Active Terminal` from the context menu.

This will be very useful when combined with the `Run In Terminal` code lens feature.

https://github.com/Shopify/vscode-ruby-lsp/assets/5079556/8df4c4de-3c34-498c-9468-bdce0a087164

### Implementation

Because `Run Selected Text in Active Terminal` is an existing command, we only need to add a menus item to `package.json`. And because it's a shortcut to manual copy-pasting, I put it in the same group as those actions, which is named `9_cutcopypaste`.

I don't want to include any fool-proof mechanism yet as it wouldn't cause any serious harm when misused (syntax error in the shell?). And the action-error relationship is very simple to understand and learn.

### Automated Tests

I don't think we can add tests for menu items?

### Manual Tests

1. Run the extension with this branch
2. In the extension development host, select a text and right click 
3. `Run Selected Text in Active Terminal` should be in the list of items
4. When clicking it, the selected text will be sent to the active terminal
