### PR TITLE
Stop manually prefixing commands with category

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,23 +35,28 @@
     "commands": [
       {
         "command": "rubyLsp.start",
-        "title": "Ruby LSP: Start"
+        "title": "Start",
+        "category": "Ruby LSP"
       },
       {
         "command": "rubyLsp.restart",
-        "title": "Ruby LSP: Restart"
+        "title": "Restart",
+        "category": "Ruby LSP"
       },
       {
         "command": "rubyLsp.stop",
-        "title": "Ruby LSP: Stop"
+        "title": "Stop",
+        "category": "Ruby LSP"
       },
       {
         "command": "rubyLsp.update",
-        "title": "Ruby LSP: Update language server gem"
+        "title": "Update language server gem",
+        "category": "Ruby LSP"
       },
       {
         "command": "rubyLsp.showSyntaxTree",
-        "title": "Ruby LSP: Show syntax tree"
+        "title": "Show syntax tree",
+        "category": "Ruby LSP"
       }
     ],
     "configuration": {


### PR DESCRIPTION
### Motivation

<!-- Closes # -->

<!-- Explain why you are making this change. Describe the problem being solved, not the solution. -->
Streamline the extension

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Extract `Ruby LSP:` prefixes to `"Ruby LSP"` category for each command.

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->
No automated tests.

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
Launch the extension on this branch and see that the command titles in the Command Palette are not changed