### PR TITLE
Add 'Testing' category for extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   },
   "categories": [
     "Programming Languages",
-    "Snippets"
+    "Snippets",
+    "Testing"
   ],
   "activationEvents": [
     "onLanguage:ruby",


### PR DESCRIPTION
### Motivation

<!-- Closes # -->

<!-- Explain why you are making this change. Describe the problem being solved, not the solution. -->
I noticed when there are no test extensions installed, VS Code shows a button that says `Install additional test extensions` which triggers an extension search with `@category:"testing"`.

In order for our extension to appear in that list, we need to add that category.
### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->
Add the category in `package.json` file.
