### PR TITLE
Mention a fallback for `chruby` users if project doesn't have `.ruby-version`

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,27 +59,10 @@ To make sure that the Ruby LSP can find the version manager scripts, make sure t
 configuration script (e.g.: ~/.bashrc, ~/.zshrc) and that the SHELL environment variable is set and pointing to the
 default shell.
 
-##### Custom activation
-
-If you're using a different version manager than the ones listed above or if you're manually inserting the Ruby
-executable into the PATH, you will probably need to define custom activation so that the extension can find the correct
-Ruby.
-
-For these cases, set `rubyLsp.rubyVersionManager` to `"custom"` and then set `rubyLsp.customRubyCommand` to a shell
-command that will activate the right Ruby version or simply add the Ruby bin folder to the PATH. Some examples:
-
-```jsonc
-{
-  // Don't forget to set the manager to custom when using this option
-  "rubyLsp.rubyVersionManager": "custom",
-
-  // Using a different version manager than the ones included by default
-  "rubyLsp.customRubyCommand": "my_custom_version_manager activate",
-
-  // Adding a custom Ruby bin folder to the PATH
-  "rubyLsp.customRubyCommand": "PATH=/path/to/ruby/bin:$PATH"
-}
-```
+> [!NOTE]
+>
+> For manager-specific notes and how to set up custom activation for managers that are not listed above,
+> please see [version managers](VERSION_MANAGERS.md).
 
 See [version managers](VERSION_MANAGERS.md) for user-contributed configuration examples.
 

--- a/VERSION_MANAGERS.md
+++ b/VERSION_MANAGERS.md
@@ -1,8 +1,32 @@
-# Custom version managers
+## Chruby
 
-Below you can find user-contributed configurations for less common version managers.
+If you use `chruby` but don't have a `.ruby-version` file in the project root, you can add `.ruby-version` to its parent folder as a fallback.
 
-## rtx
+For example, if `/projects/my_project` doesn't have `.ruby-version`, `chruby` would read `/projects/.ruby-version` instead.
+
+## Custom activation
+
+If you're using a different version manager that's not supported by this extension or if you're manually inserting the Ruby
+executable into the PATH, you will probably need to define custom activation so that the extension can find the correct
+Ruby.
+
+For these cases, set `rubyLsp.rubyVersionManager` to `"custom"` and then set `rubyLsp.customRubyCommand` to a shell
+command that will activate the right Ruby version or add the Ruby `bin` folder to the `PATH`. Some examples:
+
+```jsonc
+{
+  // Don't forget to set the manager to custom when using this option
+  "rubyLsp.rubyVersionManager": "custom",
+
+  // Using a different version manager than the ones included by default
+  "rubyLsp.customRubyCommand": "my_custom_version_manager activate",
+
+  // Adding a custom Ruby bin folder to the PATH
+  "rubyLsp.customRubyCommand": "PATH=/path/to/ruby/bin:$PATH"
+}
+```
+
+### rtx
 
 [rtx](https://github.com/jdxcode/rtx) is a Rust clone compatible with asdf. You can use it by adding the following
 snippet to your user configuration JSON


### PR DESCRIPTION
### Motivation

For `chruby` users, working on projects without `.ruby-version` (e.g. `/ruby/irb`) would cause Ruby LSP fail to start. A workaround for that is to have `.ruby-version` at a level above (e.g. `/ruby/.ruby-version`). But this information is not widely known.

### Implementation

Add note to the version manager section to explain this.

