### PR TITLE
Add default keybinding for running test

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,14 @@ palette (Default hotkey: CMD + SHIFT + P).
 | Ruby LSP: Stop                       | Stop the Ruby LSP server                                |
 | Ruby LSP: Update language server gem | Updates the `ruby-lsp` server gem to the latest version |
 
+### Keybindings
+
+Default keybindings are given below. They can be changed to suit your preference.
+
+| Command         | Default Keybinding (Mac) |
+| --------------- | ------------------------ |
+| Run in Terminal | ctrl+alt+i               |
+
 ### Snippets
 
 This extension provides convenience snippets for common Ruby constructs, such as blocks, classes, methods or even unit

--- a/package.json
+++ b/package.json
@@ -407,5 +407,12 @@
   },
   "dependencies": {
     "vscode-languageclient": "^8.1.0"
-  }
+  },
+  "keybindings": [
+    {
+      "command": "rubyLsp.runTestInTerminal",
+      "mac": "ctrl+alt+i",
+      "when": "editorTextFocus && resourceExtname == .rb/"
+    }
+  ]
 }


### PR DESCRIPTION
### Motivation

<!-- Closes # -->

<!-- Explain why you are making this change. Describe the problem being solved, not the solution. -->

### Implementation

The default is based on dev-test-runner (an internal Shopify extension).

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->
