### PR TITLE
Avoid using --disable-gems

### DIFF
--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -139,8 +139,7 @@ export class Ruby {
 
   private async activate(ruby: string) {
     let command = this.shell ? `${this.shell} -ic ` : "";
-    // eslint-disable-next-line max-len
-    command += `'${ruby} --disable-gems -rjson -e "printf(%{RUBY_ENV_ACTIVATE%sRUBY_ENV_ACTIVATE}, JSON.dump(ENV.to_h))"'`;
+    command += `'${ruby} -rjson -e "printf(%{RUBY_ENV_ACTIVATE%sRUBY_ENV_ACTIVATE}, JSON.dump(ENV.to_h))"'`;
 
     const result = await asyncExec(command, { cwd: this.workingFolder });
 
@@ -153,7 +152,7 @@ export class Ruby {
 
   private async fetchRubyInfo() {
     const rubyInfo = await asyncExec(
-      "ruby --disable-gems -e 'puts \"#{RUBY_VERSION},#{defined?(RubyVM::YJIT)}\"'",
+      "ruby -e 'puts \"#{RUBY_VERSION},#{defined?(RubyVM::YJIT)}\"'",
       { env: this._env },
     );
 


### PR DESCRIPTION
### Motivation

Closes Shopify/ruby-lsp#1641

We used `--disable-gems` to save a few milliseconds when invoking Ruby, but older versions won't allow you to require default gems when that flag is present.

The difference in performance is not so huge, we should definitely favour a nicer experience in this case.

### Implementation

Removed usages of `--disable-gems` until we can show the Ruby version error.