### PR TITLE
Make extension work on Windows

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -438,27 +438,20 @@ export default class Client implements ClientInterface {
     // If a custom Gemfile was configured outside of the project, use that. Otherwise, prefer our custom bundle over the
     // app's bundle
     if (customBundleGemfile.length > 0) {
-      bundleGemfile = `BUNDLE_GEMFILE=${customBundleGemfile}`;
+      bundleGemfile = customBundleGemfile;
     } else if (
       fs.existsSync(path.join(this.workingFolder, ".ruby-lsp", "Gemfile"))
     ) {
-      bundleGemfile = `BUNDLE_GEMFILE=${path.join(
-        this.workingFolder,
-        ".ruby-lsp",
-        "Gemfile",
-      )}`;
+      bundleGemfile = path.join(this.workingFolder, ".ruby-lsp", "Gemfile");
     } else {
-      bundleGemfile = `BUNDLE_GEMFILE=${path.join(
-        this.workingFolder,
-        "Gemfile",
-      )}`;
+      bundleGemfile = path.join(this.workingFolder, "Gemfile");
     }
 
     const result = await asyncExec(
-      `${bundleGemfile} bundle exec ruby -e "require 'ruby-lsp'; print RubyLsp::VERSION"`,
+      `bundle exec ruby -e "require 'ruby-lsp'; print RubyLsp::VERSION"`,
       {
         cwd: this.workingFolder,
-        env: this.ruby.env,
+        env: { ...this.ruby.env, BUNDLE_GEMFILE: bundleGemfile },
       },
     );
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -11,6 +11,7 @@ import {
   RevealOutputChannelOn,
   CodeLens,
   Range,
+  ExecutableOptions,
 } from "vscode-languageclient/node";
 
 import { Telemetry } from "./telemetry";
@@ -78,9 +79,10 @@ export default class Client implements ClientInterface {
       return;
     }
 
-    const executableOptions = {
+    const executableOptions: ExecutableOptions = {
       cwd: this.workingFolder,
       env: this.ruby.env,
+      shell: true,
     };
 
     const executable: Executable = {

--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -138,8 +138,12 @@ export class Ruby {
   }
 
   private async activate(ruby: string) {
-    let command = this.shell ? `${this.shell} -ic ` : "";
-    command += `'${ruby} -rjson -e "printf(%{RUBY_ENV_ACTIVATE%sRUBY_ENV_ACTIVATE}, JSON.dump(ENV.to_h))"'`;
+    let command = this.shell ? `${this.shell} -ic '` : "";
+    command += `${ruby} -rjson -e "printf(%{RUBY_ENV_ACTIVATE%sRUBY_ENV_ACTIVATE}, JSON.dump(ENV.to_h))"`;
+
+    if (this.shell) {
+      command += "'";
+    }
 
     const result = await asyncExec(command, { cwd: this.workingFolder });
 
@@ -276,8 +280,13 @@ export class Ruby {
 
   private async toolExists(tool: string) {
     try {
-      let command = this.shell ? `${this.shell} -ic ` : "";
-      command += `'${tool} --version'`;
+      let command = this.shell ? `${this.shell} -ic '` : "";
+      command += `${tool} --version`;
+
+      if (this.shell) {
+        command += "'";
+      }
+
       await asyncExec(command, { cwd: this.workingFolder });
       return true;
     } catch {


### PR DESCRIPTION
### Motivation

Closes #587

According to the explorations reported in the issue, Windows seems to need two things
1. The `shell: true` in the LSP executable. This doesn't seem to make any difference for MacOS or Linux
2. We need to remove the single quotes around commands when executing them without `this.shell`

### Implementation

Added `shell: true` and avoided adding the single quotes if `this.shell` is not defined.

### Manual Tests

On Windows,

1. Clone the repo
2. Switch to this branch
3. yarn install
4. Click F5 to start running the development version of the extension (alternatively, go to `Run and Debug` and click the launch button)
5. In the new window opened, be sure to navigate to a Ruby project where you can test the Ruby LSP
6. Verify the Ruby LSP booted properly. You can do this in multiple ways, you can
  - Check if any of the features are available
  - Go to the `Output` tab in the window where the Ruby project is opened and check for a `Ruby LSP is ready` message