### PR TITLE
allow to use the extension in folders that contain spaces

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -433,20 +433,20 @@ export default class Client implements ClientInterface {
     // If a custom Gemfile was configured outside of the project, use that. Otherwise, prefer our custom bundle over the
     // app's bundle
     if (customBundleGemfile.length > 0) {
-      bundleGemfile = `BUNDLE_GEMFILE=${customBundleGemfile}`;
+      bundleGemfile = `BUNDLE_GEMFILE="${customBundleGemfile}"`;
     } else if (
       fs.existsSync(path.join(this.workingFolder, ".ruby-lsp", "Gemfile"))
     ) {
-      bundleGemfile = `BUNDLE_GEMFILE=${path.join(
+      bundleGemfile = `BUNDLE_GEMFILE="${path.join(
         this.workingFolder,
         ".ruby-lsp",
         "Gemfile",
-      )}`;
+      )}"`;
     } else {
-      bundleGemfile = `BUNDLE_GEMFILE=${path.join(
+      bundleGemfile = `BUNDLE_GEMFILE="${path.join(
         this.workingFolder,
         "Gemfile",
-      )}`;
+      )}"`;
     }
 
     const result = await asyncExec(

--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -214,7 +214,7 @@ export class Ruby {
       );
     }
 
-    this._env.BUNDLE_GEMFILE = absoluteBundlePath;
+    this._env.BUNDLE_GEMFILE = `"${absoluteBundlePath}"`;
   }
 
   private async readRubyVersion() {


### PR DESCRIPTION
### Motivation

The extension does not work for projects in folders, were there is a space somewhere in the path. I often use that and I don't want to rename all my project folders.

### Implementation

Just adding spaces around the environment Variable named BUNDLE_GEMFILE is enough.

`BUNDLE_GEMFILE="/path with spaces/project/Gemfile" bundle exec ruby-lsp` works just fine, while
`BUNDLE_GEMFILE=/path with spaces/project/Gemfile bundle exec ruby-lsp` won't work

### Automated Tests

No, I have not included test for this. I was just about writing the tests and working on for https://github.com/Shopify/ruby-lsp/pull/781 when I recognized the extension itself was broken, too.

I might perhaps come back after the ruby-lsp itself works with spaces and add some. Meanwhile I guess the change is quite simple, and since I need to do it, to be able to work on the other issue, I could as well publish the code and add a PR, if somebody else has this.

### Manual Tests

Add a space to the folder your test project resides in, and try to start ruby-lsp. It will fail. After this change ruby-lsp can start.