### PR TITLE
Avoid running bundler commands before running custom bundle logic

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -211,9 +211,11 @@ export default class Client implements ClientInterface {
       }
     });
 
-    this.telemetry.serverVersion = await this.getServerVersion();
     await this.client.start();
+
+    // We cannot inquire anything related to the bundle before the custom bundle logic in the server runs
     await this.determineFormatter();
+    this.telemetry.serverVersion = await this.getServerVersion();
 
     this.state = ServerState.Running;
   }

--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -163,9 +163,9 @@ export class Ruby {
 
     const [major, minor, _patch] = this.rubyVersion.split(".").map(Number);
 
-    if ((major === 2 && minor < 7) || major < 2) {
+    if (major < 3) {
       throw new Error(
-        "The Ruby LSP requires Ruby 2.7 or newer to run. Please upgrade your Ruby version",
+        "The Ruby LSP requires Ruby 3.0 or newer to run. Please upgrade your Ruby version",
       );
     }
 


### PR DESCRIPTION
### Motivation

I believe these are the issues reported here https://github.com/Shopify/vscode-ruby-lsp/pull/664#issuecomment-1646375400.

We can't make any bundler inquiries before starting the server. Now that the custom bundle logic runs on the server, the bundle will only be installed after the server booted successfully. Trying to read the server version before starting will always fail if the gems aren't installed (because we haven't run bundle install yet).

Additionally, we need to fully deprecate Ruby 2.7. Because the gem now requires Ruby >=3.0, using `gem install ruby-lsp` will never install `v0.7.3`, which means it's impossible to use the extension with Ruby 2.7.

### Implementation

- Moved the server version check after the custom bundle logic
- Changed the Ruby version check