### PR TITLE
Add client start test

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -44,8 +44,9 @@ export default class Client implements ClientInterface {
     telemetry: Telemetry,
     ruby: Ruby,
     testController: TestController,
+    workingFolder = vscode.workspace.workspaceFolders![0].uri.fsPath,
   ) {
-    this.workingFolder = vscode.workspace.workspaceFolders![0].uri.fsPath;
+    this.workingFolder = workingFolder;
     this.telemetry = telemetry;
     this.testController = testController;
     this.#context = context;

--- a/src/test/suite/client.test.ts
+++ b/src/test/suite/client.test.ts
@@ -1,0 +1,80 @@
+import * as assert from "assert";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+import { afterEach } from "mocha";
+import * as vscode from "vscode";
+
+import { Ruby } from "../../ruby";
+import { Telemetry, TelemetryApi, TelemetryEvent } from "../../telemetry";
+import { TestController } from "../../testController";
+import { ServerState } from "../../status";
+import Client from "../../client";
+
+class FakeApi implements TelemetryApi {
+  public sentEvents: TelemetryEvent[];
+
+  constructor() {
+    this.sentEvents = [];
+  }
+
+  async sendEvent(event: TelemetryEvent): Promise<void> {
+    this.sentEvents.push(event);
+  }
+}
+
+suite("Client", () => {
+  let client: Client;
+  let testController: TestController;
+  const managerConfig = vscode.workspace.getConfiguration("rubyLsp");
+  const currentManager = managerConfig.get("rubyVersionManager");
+  const tmpPath = fs.mkdtempSync(path.join(os.tmpdir(), "ruby-lsp-test-"));
+
+  afterEach(async () => {
+    if (client && client.state === ServerState.Running) {
+      await client.stop();
+    }
+
+    if (testController) {
+      testController.dispose();
+    }
+
+    managerConfig.update("rubyVersionManager", currentManager, true, true);
+    fs.rmSync(tmpPath, { recursive: true, force: true });
+  });
+
+  test("Starting up the server succeeds", async () => {
+    // await managerConfig.update("rubyVersionManager", "none", true, true);
+    const context = {
+      extensionMode: vscode.ExtensionMode.Test,
+      subscriptions: [],
+      workspaceState: {
+        get: (_name: string) => undefined,
+        update: (_name: string, _value: any) => Promise.resolve(),
+      },
+    } as unknown as vscode.ExtensionContext;
+
+    const ruby = new Ruby(context, tmpPath);
+    await ruby.activateRuby();
+
+    const telemetry = new Telemetry(context, new FakeApi());
+
+    const testController = new TestController(
+      context,
+      tmpPath,
+      ruby,
+      telemetry,
+    );
+
+    const client = new Client(
+      context,
+      telemetry,
+      ruby,
+      testController,
+      tmpPath,
+    );
+    await client.start();
+    assert.strictEqual(client.state, ServerState.Running);
+  }).timeout(30000);
+});


### PR DESCRIPTION
### Motivation

We don't have nearly enough tests on the extension side and that's something I would really like to change moving forward. This PR adds a boot test for the client/server.

### Implementation

The idea of the test is to launch the real server on a temporary directory and verify that we succeed in doing so.

This specific test only covers the scenario where there's no bundle, but we can add more examples using this one as a base.