### PR TITLE
Wrap BUNDLE_GEMFILE path in quotes

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -436,20 +436,20 @@ export default class Client implements ClientInterface {
     // If a custom Gemfile was configured outside of the project, use that. Otherwise, prefer our custom bundle over the
     // app's bundle
     if (customBundleGemfile.length > 0) {
-      bundleGemfile = `BUNDLE_GEMFILE=${customBundleGemfile}`;
+      bundleGemfile = `BUNDLE_GEMFILE="${customBundleGemfile}"`;
     } else if (
       fs.existsSync(path.join(this.workingFolder, ".ruby-lsp", "Gemfile"))
     ) {
-      bundleGemfile = `BUNDLE_GEMFILE=${path.join(
+      bundleGemfile = `BUNDLE_GEMFILE="${path.join(
         this.workingFolder,
         ".ruby-lsp",
         "Gemfile",
-      )}`;
+      )}"`;
     } else {
-      bundleGemfile = `BUNDLE_GEMFILE=${path.join(
+      bundleGemfile = `BUNDLE_GEMFILE="${path.join(
         this.workingFolder,
         "Gemfile",
-      )}`;
+      )}"`;
     }
 
     const result = await asyncExec(


### PR DESCRIPTION
### Motivation

I store some of my projects in iCloud, so paths start with `~/Library/Mobile Documents/com~apple~CloudDocs`, which has a space. Without this change, `getServerVersion` fails with (for example)

```
Error restarting the server: Command failed: BUNDLE_GEMFILE=/Users/jordancole/Library/Mobile Documents/com~apple~CloudDocs/Projects/drjohndee.net/.ruby-lsp/Gemfile bundle exec ruby -e "require 'ruby-lsp'; print RubyLsp::VERSION"
/bin/sh: Documents/com~apple~CloudDocs/Projects/drjohndee.net/.ruby-lsp/Gemfile: No such file or directory
```

The error shows that this is parsed as running `Documents/com~apple~CloudDocs/Projects/drjohndee.net/.ruby-lsp/Gemfile` with `BUNDLE_GEMFILE=/Users/jordancole/Library/Mobile` as an environment variable.

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

I searched for `BUNDLE_GEMFILE` and wrapped the assignment in double quotes. It’s simplistic, but I think it's correct.

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

I haven't added tests because I'm not sure how to implement them.

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->

```shell
mkdir -p ~/"vscode-ruby-lsp path-test"
cd ~/"vscode-ruby-lsp path-test"
echo "puts 1" > test.rb
code .
```

`Client.getServerVersion` should run without error.