### PR TITLE
Expand test status and output

### DIFF
--- a/src/testController.ts
+++ b/src/testController.ts
@@ -242,8 +242,13 @@ export class TestController {
             new vscode.TestMessage(err.message),
             new vscode.TestMessage(summary),
           ];
+          const duration = Date.now() - start;
 
-          run.failed(test, messages, Date.now() - start);
+          if (messageArr.find((elem: string) => elem === "F")) {
+            run.failed(test, messages, duration);
+          } else {
+            run.errored(test, messages, duration);
+          }
         }
       }
 


### PR DESCRIPTION
### Motivation

There are two purposes for this pr:
1. Add more test statuses which is reflected on the icons in the gutter & test controller/explorer (what's the right term?), including `enqueued`, `started` and `errored` 
2. Include the full test result so the debugging messages (via `puts` for example) can be inspected in the "Test results" panel 


### Implementation

For adding statuses, the vscode [TestRun object ](https://code.visualstudio.com/api/references/vscode-api#TestRun)already provides APIs for transitioning into different statuses, so it's only a matter of inserting the ones we haven't used in the right place. 

One thing to note is in order to distinguish between a failure and an error, I implemented this logic that searches for an arbitrary string `"F"` in the result, but I haven't been able to test my changes on a repo that uses test-unit yet, so there's a chance that it might now work on repos with test-unit.

As for adding the full test results–I'm using [`TestRun#appendOutput`](https://code.visualstudio.com/api/references/vscode-api#TestRun) for a successful test and changing the message field for `#errored` & `#failed` from type of `string` to an array of strings instead, and ordered it so that the summary message is still shown on peek/hover, while the full message can be expanded in the Test results panel.

### Automated Tests

There doesn't seem to be existing tests for TestController? I'd be happy to add some if that's desirable. 

### Manual Tests

1. Open the project in vscode, switch to this branch
2. Click "Run extension" from the debug section
3. Open a project that uses the Minitset or test/unit framework. I use [ruby-lsp](https://github.com/shopify/ruby-lsp/) for Minitest. Would love recommendations on repos that use test-unit 😅
4. Set up ruby-lsp if haven't
5. Open a test file and run
6. Observe results: 
    - On the test controller and gutter, icons change through the statuses pending -> running -> result (success/failure/error)
    - Error messages pop up for failed or errored tests (existing functionality)
    - On the test results  panel, expand the test runs and the full test output should show for all three kinds of results (success/failure/error). 

Tophat video 👉🏼 https://screenshot.click/28-44-gotyf-bjlwh.mp4