### PR TITLE
Recover from custom bundle failures

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -211,7 +211,15 @@ export default class Client implements ClientInterface {
       }
     });
 
-    await this.client.start();
+    try {
+      await this.client.start();
+    } catch (error: any) {
+      this.state = ServerState.Error;
+      this.outputChannel.appendLine(
+        `Error restarting the server: ${error.message}`,
+      );
+      return;
+    }
 
     // We cannot inquire anything related to the bundle before the custom bundle logic in the server runs
     await this.determineFormatter();


### PR DESCRIPTION
### Motivation

Now that the custom bundle logic runs in the server, we need to make sure to fail gracefully when starting the server, otherwise our restart watchers won't work.

Currently, if the custom bundle logic fails for any reason, the server state is set to `Starting` and so invoking `client.restart` does nothing. It also means that multiple errors are shown to the user. We need to make sure we set the right server state as well as failing better.

### Implementation

Wrapped the invocation of `client.start` in a try/catch block. This is when we trigger the custom bundle logic. If this fails, then we print to the output channel and set the server state to `Error`, so that we can restart automatically if the bundler issue is addressed.