### PR TITLE
Add early return when shadowenv returns an empty string

### DIFF
--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -122,8 +122,11 @@ export class Ruby {
       cwd: this.workingFolder,
     });
 
-    if (result.stdout === "") return;
-
+    if (result.stdout === "") {
+      // eslint-disable-next-line no-process-env
+      this._env = { ...process.env };
+      return;
+    };
     // eslint-disable-next-line no-process-env
     const env = { ...process.env, ...JSON.parse(result.stdout).exported };
 

--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -122,6 +122,8 @@ export class Ruby {
       cwd: this.workingFolder,
     });
 
+    if (result.stdout === "") return;
+
     // eslint-disable-next-line no-process-env
     const env = { ...process.env, ...JSON.parse(result.stdout).exported };
 

--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -122,11 +122,9 @@ export class Ruby {
       cwd: this.workingFolder,
     });
 
-    if (result.stdout === "") {
-      // eslint-disable-next-line no-process-env
-      this._env = { ...process.env };
-      return;
-    };
+    if (result.stdout.trim() === "") {
+      result.stdout = "{ }";
+    }
     // eslint-disable-next-line no-process-env
     const env = { ...process.env, ...JSON.parse(result.stdout).exported };
 


### PR DESCRIPTION
### Motivation

Raised by @EsterKais, shadowenv has been failing because we are expecting `shadowenv hook --json` to return valid json. It is possible that this command won't print anything to stdout which will result in an empty string instead.

### Implementation

Check command output, returning early if it is empty.