### PR TITLE
Remove scheme from document selector

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -97,7 +97,7 @@ export default class Client implements ClientInterface {
 
     const configuration = vscode.workspace.getConfiguration("rubyLsp");
     const clientOptions: LanguageClientOptions = {
-      documentSelector: [{ scheme: "file", language: "ruby" }],
+      documentSelector: [{ language: "ruby" }],
       diagnosticCollectionName: LSP_NAME,
       outputChannel: this.outputChannel,
       revealOutputChannelOn: RevealOutputChannelOn.Never,


### PR DESCRIPTION
### Motivation

Closes #https://github.com/Shopify/ruby-lsp/issues/633

Now that we have standardized URI usage in the server, we should be able to handle scheme as long as the language is Ruby.

### Implementation

Just removing the `scheme` from the filter should make us handle any Ruby file under any scheme.