### PR TITLE
Time out tests that don't finish under 30 seconds

### DIFF
--- a/package.json
+++ b/package.json
@@ -233,6 +233,11 @@
           "description": "Relative path to the Gemfile to use for bundling the Ruby LSP server. Only necessary when using a separate Gemfile for the Ruby LSP",
           "type": "string",
           "default": ""
+        },
+        "rubyLsp.testTimeout": {
+          "description": "The amount of time in seconds to wait for a test to finish before timing out. Only used when running tests from the test explorer",
+          "type": "integer",
+          "default": 30
         }
       }
     },


### PR DESCRIPTION
### Motivation

If someone forgets a debugger statement in a test, running it in the test explorer will hang forever. We should instead add a timeout, so that the editor doesn't get into a bad state.

### Implementation

Added a timeout to the exec call. If the timeout is exceeded, than `error.killed` will be `true` and we can add special handling to it.

I put the timeout at 30 seconds. Not sure if it's too much, but I wanted to avoid slow tests accidentally timing out.