### PR TITLE
Allow using absolute paths for custom bundle configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,12 +97,17 @@ The tool to be used for formatting files can be configured with the following se
 
 #### Using a custom Gemfile
 
-If you are working on a project using an older version of Ruby not supported by Ruby LSP, then you will need you specify a separate `Gemfile` for development tools. You can include the `ruby-lsp` in it and point to that Gemfile by using the following configuration:
+If you are working on a project using an older version of Ruby not supported by Ruby LSP, then you may specify a
+separate `Gemfile` for development tools. You can include the `ruby-lsp` in it and point to that Gemfile by using the
+following configuration:
 
 **Note**: when using this, gems will not be installed automatically and neither will `ruby-lsp` upgrades.
 
 ```jsonc
-"rubyLsp.bundleGemfile": "relative/path/to/Gemfile"
+{
+  "rubyLsp.bundleGemfile": "../../relative/path/to/Gemfile", // using a relative path from the current project
+  "rubyLsp.bundleGemfile": "/absolute/path/to/Gemfile" // using an absolute path
+}
 ```
 
 #### Configuring VS Code debugger

--- a/package.json
+++ b/package.json
@@ -230,7 +230,7 @@
           "default": "auto"
         },
         "rubyLsp.bundleGemfile": {
-          "description": "Relative path to the Gemfile to use for bundling the Ruby LSP server. Only necessary when using a separate Gemfile for the Ruby LSP",
+          "description": "Relative or absolute path to the Gemfile to use for bundling the Ruby LSP server. Only necessary when using a separate Gemfile for the Ruby LSP",
           "type": "string",
           "default": ""
         }

--- a/src/client.ts
+++ b/src/client.ts
@@ -437,7 +437,9 @@ export default class Client implements ClientInterface {
     // If a custom Gemfile was configured outside of the project, use that. Otherwise, prefer our custom bundle over the
     // app's bundle
     if (this.hasUserDefinedCustomBundle()) {
-      bundleGemfile = this.customBundleGemfile;
+      bundleGemfile = path.isAbsolute(this.customBundleGemfile)
+        ? this.customBundleGemfile
+        : path.resolve(path.join(this.workingFolder, this.customBundleGemfile));
     } else if (
       fs.existsSync(path.join(this.workingFolder, ".ruby-lsp", "Gemfile"))
     ) {

--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -211,9 +211,9 @@ export class Ruby {
       return;
     }
 
-    const absoluteBundlePath = path.resolve(
-      path.join(this.workingFolder, customBundleGemfile),
-    );
+    const absoluteBundlePath = path.isAbsolute(customBundleGemfile)
+      ? customBundleGemfile
+      : path.resolve(path.join(this.workingFolder, customBundleGemfile));
 
     if (!fs.existsSync(absoluteBundlePath)) {
       throw new Error(


### PR DESCRIPTION
### Motivation

If users want to keep a separate Gemfile for development tools to be used in all projects, then configuring that with a relative path might be a lot of work. Allowing users to configure an absolute path to an external bundle is easier because that will work for any project.

### Implementation

We now allow both relative or absolute path. The implementation checks if the path is absolute and then decides whether to use it directly or to expand it.