### PR TITLE
Make dependabot tag the right team and run at the regular schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,10 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
-      day: tuesday
-      time: "10:00"
-      timezone: America/New_York
     reviewers:
-      - "Shopify/sorbet"
+      - "Shopify/ruby-dev-exp"
     ignore:
       - dependency-name: "@types/vscode"


### PR DESCRIPTION
### Motivation

I think we initially set dependabot to run only on Tuesdays because we didn't have the auto-merge automation back then. There's no point to wait until Tuesday 10:00 AM when the vast majority of PRs are just merged automatically.

I also updated the team to match the right one.