### PR TITLE
Narrow document selector to file and untitled schemes

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -87,7 +87,10 @@ export default class Client implements ClientInterface {
 
     const configuration = vscode.workspace.getConfiguration("rubyLsp");
     const clientOptions: LanguageClientOptions = {
-      documentSelector: [{ language: "ruby" }],
+      documentSelector: [
+        { scheme: "file", language: "ruby" },
+        { scheme: "untitled", language: "ruby" },
+      ],
       diagnosticCollectionName: LSP_NAME,
       outputChannel: this.outputChannel,
       revealOutputChannelOn: RevealOutputChannelOn.Never,


### PR DESCRIPTION
### Motivation

In #745, we made the document selector a little too broad. There are some schemes that we're not interested in handling.

For example, when looking at a diff in VS Code, it opens both a `file` version of the document and a `git` version. Because both have the same path and VS Code sends requests for the two versions, they end up overriding each other and leads to weird issues.

### Implementation

Narrowed our selector to handle only file and untitled.