### PR TITLE
Enable typechecking plugin

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,14 @@
 {
   "root": true,
   "parser": "@typescript-eslint/parser",
-  "extends": ["plugin:@shopify/typescript", "plugin:@shopify/prettier"],
+  "extends": [
+    "plugin:@shopify/typescript",
+    "plugin:@shopify/typescript-type-checking",
+    "plugin:@shopify/prettier"
+  ],
+  "parserOptions": {
+    "project": "tsconfig.json"
+  },
   "settings": {
     "import/resolver": {
       "typescript": {
@@ -18,6 +25,11 @@
     "eqeqeq": "error",
     "no-invalid-this": "error",
     "no-lonely-if": "error",
-    "max-len": ["error", { "code": 120 }]
+    "max-len": [
+      "error",
+      {
+        "code": 120
+      }
+    ]
   }
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -31,12 +31,12 @@ type SyntaxTreeResponse = { ast: string } | null;
 
 export default class Client implements ClientInterface {
   private client: LanguageClient | undefined;
-  private workingFolder: string;
-  private telemetry: Telemetry;
-  private statusItems: StatusItems;
-  private outputChannel = vscode.window.createOutputChannel(LSP_NAME);
-  private testController: TestController;
-  private customBundleGemfile: string = vscode.workspace
+  private readonly workingFolder: string;
+  private readonly telemetry: Telemetry;
+  private readonly statusItems: StatusItems;
+  private readonly outputChannel = vscode.window.createOutputChannel(LSP_NAME);
+  private readonly testController: TestController;
+  private readonly customBundleGemfile: string = vscode.workspace
     .getConfiguration("rubyLsp")
     .get("bundleGemfile")!;
 

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -11,11 +11,11 @@ export class Debugger
     vscode.DebugAdapterDescriptorFactory,
     vscode.DebugConfigurationProvider
 {
-  private workingFolder: string;
-  private ruby: Ruby;
+  private readonly workingFolder: string;
+  private readonly ruby: Ruby;
   private debugProcess?: ChildProcessWithoutNullStreams;
-  private console = vscode.debug.activeDebugConsole;
-  private subscriptions: vscode.Disposable[];
+  private readonly console = vscode.debug.activeDebugConsole;
+  private readonly subscriptions: vscode.Disposable[];
 
   constructor(
     context: vscode.ExtensionContext,
@@ -118,6 +118,7 @@ export class Debugger
       .map((file) => file)
       .filter((file) => file.endsWith(".sock"));
 
+    // eslint-disable-next-line @typescript-eslint/no-misused-promises
     return new Promise((resolve, reject) => {
       if (sockets.length === 0) {
         reject(new Error("No debuggee processes found"));
@@ -231,7 +232,7 @@ export class Debugger
     if (existingSockets.length > 0) {
       socketIndex =
         Number(
-          existingSockets[existingSockets.length - 1].match(/-(\d+).sock$/)![1],
+          /-(\d+).sock$/.exec(existingSockets[existingSockets.length - 1])![1],
         ) + 1;
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,9 +7,9 @@ import { Debugger } from "./debugger";
 import { TestController } from "./testController";
 import DocumentProvider from "./documentProvider";
 
-let client: Client;
-let debug: Debugger;
-let testController: TestController;
+let client: Client | undefined;
+let debug: Debugger | undefined;
+let testController: TestController | undefined;
 
 export async function activate(context: vscode.ExtensionContext) {
   const ruby = new Ruby(context);

--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -22,13 +22,13 @@ export class Ruby {
   public rubyVersion?: string;
   public yjitEnabled?: boolean;
   public supportsYjit?: boolean;
-  private workingFolder: string;
+  private readonly workingFolder: string;
   #versionManager?: VersionManager;
   // eslint-disable-next-line no-process-env
-  private shell = process.env.SHELL;
+  private readonly shell = process.env.SHELL;
   private _env: NodeJS.ProcessEnv = {};
   private _error = false;
-  private context: vscode.ExtensionContext;
+  private readonly context: vscode.ExtensionContext;
 
   constructor(
     context: vscode.ExtensionContext,
@@ -136,7 +136,7 @@ export class Ruby {
   }
 
   private async activateChruby() {
-    const rubyVersion = await this.readRubyVersion();
+    const rubyVersion = this.readRubyVersion();
     await this.activate(`chruby "${rubyVersion}" && ruby`);
   }
 
@@ -150,8 +150,8 @@ export class Ruby {
 
     const result = await asyncExec(command, { cwd: this.workingFolder });
 
-    const envJson = result.stdout.match(
-      /RUBY_ENV_ACTIVATE(.*)RUBY_ENV_ACTIVATE/,
+    const envJson = /RUBY_ENV_ACTIVATE(.*)RUBY_ENV_ACTIVATE/.exec(
+      result.stdout,
     )![1];
 
     this._env = JSON.parse(envJson);
@@ -224,7 +224,7 @@ export class Ruby {
     this._env.BUNDLE_GEMFILE = absoluteBundlePath;
   }
 
-  private async readRubyVersion() {
+  private readRubyVersion() {
     let dir = this.workingFolder;
 
     while (fs.existsSync(dir)) {

--- a/src/status.ts
+++ b/src/status.ts
@@ -375,7 +375,7 @@ export class FormatterStatus extends StatusItem {
 }
 
 export class StatusItems {
-  private items: StatusItem[] = [];
+  private readonly items: StatusItem[] = [];
 
   constructor(client: ClientInterface) {
     this.items = [

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -33,6 +33,7 @@ export interface TelemetryApi {
 }
 
 class DevelopmentApi implements TelemetryApi {
+  // eslint-disable-next-line @typescript-eslint/require-await
   async sendEvent(event: TelemetryEvent): Promise<void> {
     // eslint-disable-next-line no-console
     console.log(event);
@@ -42,7 +43,7 @@ class DevelopmentApi implements TelemetryApi {
 export class Telemetry {
   public serverVersion?: string;
   private api?: TelemetryApi;
-  private context: vscode.ExtensionContext;
+  private readonly context: vscode.ExtensionContext;
 
   constructor(context: vscode.ExtensionContext, api?: TelemetryApi) {
     this.context = context;

--- a/src/test/suite/client.test.ts
+++ b/src/test/suite/client.test.ts
@@ -19,14 +19,15 @@ class FakeApi implements TelemetryApi {
     this.sentEvents = [];
   }
 
+  // eslint-disable-next-line @typescript-eslint/require-await
   async sendEvent(event: TelemetryEvent): Promise<void> {
     this.sentEvents.push(event);
   }
 }
 
 suite("Client", () => {
-  let client: Client;
-  let testController: TestController;
+  let client: Client | undefined;
+  let testController: TestController | undefined;
   const managerConfig = vscode.workspace.getConfiguration("rubyLsp");
   const currentManager = managerConfig.get("rubyVersionManager");
   const tmpPath = fs.mkdtempSync(path.join(os.tmpdir(), "ruby-lsp-test-"));

--- a/src/test/suite/status.test.ts
+++ b/src/test/suite/status.test.ts
@@ -47,18 +47,18 @@ suite("StatusItems", () => {
       status = new RubyVersionStatus(client);
     });
 
-    test("Status is initialized with the right values", async () => {
+    test("Status is initialized with the right values", () => {
       assert.strictEqual(status.item.text, "Using Ruby 3.2.0 with shadowenv");
       assert.strictEqual(status.item.name, "Ruby LSP Status");
       assert.strictEqual(status.item.command?.title, "Change version manager");
       assert.strictEqual(
-        status.item.command?.command,
+        status.item.command.command,
         Command.SelectVersionManager,
       );
       assert.strictEqual(context.subscriptions.length, 1);
     });
 
-    test("Refresh updates version string", async () => {
+    test("Refresh updates version string", () => {
       assert.strictEqual(status.item.text, "Using Ruby 3.2.0 with shadowenv");
 
       client.ruby.rubyVersion = "3.2.1";
@@ -74,7 +74,7 @@ suite("StatusItems", () => {
       status = new ServerStatus(client);
     });
 
-    test("Status is initialized with the right values", async () => {
+    test("Status is initialized with the right values", () => {
       assert.strictEqual(status.item.text, "Ruby LSP: Starting");
       assert.strictEqual(status.item.name, "Ruby LSP Status");
       assert.strictEqual(
@@ -82,11 +82,11 @@ suite("StatusItems", () => {
         vscode.LanguageStatusSeverity.Information,
       );
       assert.strictEqual(status.item.command?.title, "Configure");
-      assert.strictEqual(status.item.command?.command, Command.ServerOptions);
+      assert.strictEqual(status.item.command.command, Command.ServerOptions);
       assert.strictEqual(context.subscriptions.length, 1);
     });
 
-    test("Refresh when server is starting", async () => {
+    test("Refresh when server is starting", () => {
       client.state = ServerState.Starting;
       status.refresh();
       assert.strictEqual(status.item.text, "Ruby LSP: Starting");
@@ -96,7 +96,7 @@ suite("StatusItems", () => {
       );
     });
 
-    test("Refresh when server is running", async () => {
+    test("Refresh when server is running", () => {
       client.state = ServerState.Running;
       status.refresh();
       assert.strictEqual(status.item.text, "Ruby LSP: Running");
@@ -106,7 +106,7 @@ suite("StatusItems", () => {
       );
     });
 
-    test("Refresh when server is stopping", async () => {
+    test("Refresh when server is stopping", () => {
       client.state = ServerState.Stopped;
       status.refresh();
       assert.strictEqual(status.item.text, "Ruby LSP: Stopped");
@@ -116,7 +116,7 @@ suite("StatusItems", () => {
       );
     });
 
-    test("Refresh when server has errored", async () => {
+    test("Refresh when server has errored", () => {
       client.state = ServerState.Error;
       status.refresh();
       assert.strictEqual(status.item.text, "Ruby LSP: Error");
@@ -139,12 +139,12 @@ suite("StatusItems", () => {
       status = new ExperimentalFeaturesStatus(client);
     });
 
-    test("Status is initialized with the right values", async () => {
+    test("Status is initialized with the right values", () => {
       assert.strictEqual(status.item.text, "Experimental features disabled");
       assert.strictEqual(status.item.name, "Experimental features");
       assert.strictEqual(status.item.command?.title, "Enable");
       assert.strictEqual(
-        status.item.command?.command,
+        status.item.command.command,
         Command.ToggleExperimentalFeatures,
       );
       assert.strictEqual(context.subscriptions.length, 1);
@@ -158,15 +158,15 @@ suite("StatusItems", () => {
       status = new YjitStatus(client);
     });
 
-    test("Status is initialized with the right values", async () => {
+    test("Status is initialized with the right values", () => {
       assert.strictEqual(status.item.text, "YJIT enabled");
       assert.strictEqual(status.item.name, "YJIT");
       assert.strictEqual(status.item.command?.title, "Disable");
-      assert.strictEqual(status.item.command?.command, Command.ToggleYjit);
+      assert.strictEqual(status.item.command.command, Command.ToggleYjit);
       assert.strictEqual(context.subscriptions.length, 1);
     });
 
-    test("Refresh updates whether it's disabled or enabled", async () => {
+    test("Refresh updates whether it's disabled or enabled", () => {
       assert.strictEqual(status.item.text, "YJIT enabled");
 
       client.ruby.supportsYjit = false;
@@ -182,7 +182,7 @@ suite("StatusItems", () => {
       status = new YjitStatus(client);
     });
 
-    test("Refresh ignores YJIT configuration if Ruby doesn't support it", async () => {
+    test("Refresh ignores YJIT configuration if Ruby doesn't support it", () => {
       assert.strictEqual(status.item.text, "YJIT disabled");
       assert.strictEqual(status.item.command, undefined);
 
@@ -219,7 +219,7 @@ suite("StatusItems", () => {
       configuration.update("enabledFeatures", originalFeatures, true, true);
     });
 
-    test("Status is initialized with the right values", async () => {
+    test("Status is initialized with the right values", () => {
       assert.strictEqual(
         status.item.text,
         `${
@@ -228,7 +228,7 @@ suite("StatusItems", () => {
       );
       assert.strictEqual(status.item.name, "Ruby LSP Features");
       assert.strictEqual(status.item.command?.title, "Manage");
-      assert.strictEqual(status.item.command?.command, Command.ToggleFeatures);
+      assert.strictEqual(status.item.command.command, Command.ToggleFeatures);
       assert.strictEqual(context.subscriptions.length, 1);
     });
 
@@ -271,11 +271,11 @@ suite("StatusItems", () => {
       status = new FormatterStatus(client);
     });
 
-    test("Status is initialized with the right values", async () => {
+    test("Status is initialized with the right values", () => {
       assert.strictEqual(status.item.text, "Using formatter: auto");
       assert.strictEqual(status.item.name, "Formatter");
       assert.strictEqual(status.item.command?.title, "Help");
-      assert.strictEqual(status.item.command?.command, Command.FormatterHelp);
+      assert.strictEqual(status.item.command.command, Command.FormatterHelp);
       assert.strictEqual(context.subscriptions.length, 1);
     });
   });

--- a/src/test/suite/telemetry.test.ts
+++ b/src/test/suite/telemetry.test.ts
@@ -17,6 +17,7 @@ class FakeApi implements TelemetryApi {
     this.sentEvents = [];
   }
 
+  // eslint-disable-next-line @typescript-eslint/require-await
   async sendEvent(event: TelemetryEvent): Promise<void> {
     this.sentEvents.push(event);
   }

--- a/src/testController.ts
+++ b/src/testController.ts
@@ -13,17 +13,17 @@ const asyncExec = promisify(exec);
 const TERMINAL_NAME = "Ruby LSP: Run test";
 
 export class TestController {
-  private testController: vscode.TestController;
-  private testCommands: WeakMap<vscode.TestItem, string>;
-  private testRunProfile: vscode.TestRunProfile;
-  private testDebugProfile: vscode.TestRunProfile;
-  private debugTag: vscode.TestTag = new vscode.TestTag("debug");
-  private workingFolder: string;
+  private readonly testController: vscode.TestController;
+  private readonly testCommands: WeakMap<vscode.TestItem, string>;
+  private readonly testRunProfile: vscode.TestRunProfile;
+  private readonly testDebugProfile: vscode.TestRunProfile;
+  private readonly debugTag: vscode.TestTag = new vscode.TestTag("debug");
+  private readonly workingFolder: string;
   private terminal: vscode.Terminal | undefined;
-  private ruby: Ruby;
-  private telemetry: Telemetry;
+  private readonly ruby: Ruby;
+  private readonly telemetry: Telemetry;
   // We allow the timeout to be configured in seconds, but exec expects it in milliseconds
-  private testTimeout = vscode.workspace
+  private readonly testTimeout = vscode.workspace
     .getConfiguration("rubyLsp")
     .get("testTimeout") as number;
 
@@ -141,7 +141,7 @@ export class TestController {
     this.testController.dispose();
   }
 
-  private debugTest(_path: string, _name: string, command: string) {
+  private debugTest(_path: string, _name: string, command?: string) {
     // eslint-disable-next-line no-param-reassign
     command ??= this.testCommands.get(this.findTestByActiveLine()!) || "";
 
@@ -157,7 +157,7 @@ export class TestController {
   private async runTestInTerminal(
     _path: string,
     _name: string,
-    command: string,
+    command?: string,
   ) {
     // eslint-disable-next-line no-param-reassign
     command ??= this.testCommands.get(this.findTestByActiveLine()!) || "";
@@ -292,7 +292,7 @@ export class TestController {
     }
   }
 
-  private async runOnClick(testId: string) {
+  private runOnClick(testId: string) {
     const test = this.findTestById(testId);
 
     if (!test) return;


### PR DESCRIPTION
### Motivation

We didn't have `"plugin:@shopify/typescript-type-checking"` enabled and were missing out on some typechecking features.

### Implementation

This PR adds the plugin and fixes the typechecking issues surfaced.