### PR TITLE
Add configuration to specify branch for server

### DIFF
--- a/package.json
+++ b/package.json
@@ -238,6 +238,11 @@
           "description": "The amount of time in seconds to wait for a test to finish before timing out. Only used when running tests from the test explorer",
           "type": "integer",
           "default": 30
+        },
+        "rubyLsp.branch": {
+          "description": "Run the Ruby LSP server from the specified branch rather than using the released gem. Only supported if not using bundleGemfile",
+          "type": "string",
+          "default": ""
         }
       }
     },

--- a/src/client.ts
+++ b/src/client.ts
@@ -539,6 +539,9 @@ export default class Client implements ClientInterface {
   private executables(): ServerOptions {
     let run: Executable;
     let debug: Executable;
+    const branch: string = vscode.workspace
+      .getConfiguration("rubyLsp")
+      .get("branch")!;
 
     const executableOptions: ExecutableOptions = {
       cwd: this.workingFolder,
@@ -563,7 +566,7 @@ export default class Client implements ClientInterface {
     } else {
       run = {
         command: "ruby-lsp",
-        args: [],
+        args: branch.length > 0 ? ["--branch", branch] : [],
         options: executableOptions,
       };
 


### PR DESCRIPTION
### Motivation

Second part of https://github.com/Shopify/ruby-lsp/pull/897

Allow configuring which branch of the LSP to run with, so that we can test impactful changes ahead of time without merging PRs.

### Implementation

Added the configuration and started pushing the `--branch something` option to the executable when booting. Notice that this option is only available when running from the global installation, so there's no need to add it to the other cases.