### PR TITLE
Show server version in status language item

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -272,6 +272,10 @@ export default class Client implements ClientInterface {
     return this.#formatter;
   }
 
+  get serverVersion(): string | undefined {
+    return this.telemetry.serverVersion;
+  }
+
   async determineFormatter() {
     const configuration = vscode.workspace.getConfiguration("rubyLsp");
     const configuredFormatter: string = configuration.get("formatter")!;

--- a/src/status.ts
+++ b/src/status.ts
@@ -43,6 +43,7 @@ export interface ClientInterface {
   ruby: Ruby;
   state: ServerState;
   formatter: string;
+  serverVersion: string | undefined;
 }
 
 export abstract class StatusItem {
@@ -132,7 +133,7 @@ export class ServerStatus extends StatusItem {
   refresh(): void {
     switch (this.client.state) {
       case ServerState.Running: {
-        this.item.text = "Ruby LSP: Running";
+        this.item.text = `Ruby LSP v${this.client.serverVersion}: Running`;
         this.item.command!.arguments = [STARTED_SERVER_OPTIONS];
         this.item.severity = vscode.LanguageStatusSeverity.Information;
         break;

--- a/src/test/suite/status.test.ts
+++ b/src/test/suite/status.test.ts
@@ -43,6 +43,7 @@ suite("StatusItems", () => {
         ruby,
         state: ServerState.Running,
         formatter: "none",
+        serverVersion: "1.0.0",
       };
       status = new RubyVersionStatus(client);
     });
@@ -70,7 +71,13 @@ suite("StatusItems", () => {
   suite("ServerStatus", () => {
     beforeEach(() => {
       ruby = {} as Ruby;
-      client = { context, ruby, state: ServerState.Running, formatter: "none" };
+      client = {
+        context,
+        ruby,
+        state: ServerState.Running,
+        formatter: "none",
+        serverVersion: "1.0.0",
+      };
       status = new ServerStatus(client);
     });
 
@@ -99,7 +106,7 @@ suite("StatusItems", () => {
     test("Refresh when server is running", () => {
       client.state = ServerState.Running;
       status.refresh();
-      assert.strictEqual(status.item.text, "Ruby LSP: Running");
+      assert.strictEqual(status.item.text, "Ruby LSP v1.0.0: Running");
       assert.strictEqual(
         status.item.severity,
         vscode.LanguageStatusSeverity.Information,
@@ -135,6 +142,7 @@ suite("StatusItems", () => {
         ruby,
         formatter,
         state: ServerState.Running,
+        serverVersion: "1.0.0",
       };
       status = new ExperimentalFeaturesStatus(client);
     });
@@ -154,7 +162,13 @@ suite("StatusItems", () => {
   suite("YjitStatus when Ruby supports it", () => {
     beforeEach(() => {
       ruby = { supportsYjit: true } as Ruby;
-      client = { context, ruby, state: ServerState.Running, formatter: "none" };
+      client = {
+        context,
+        ruby,
+        state: ServerState.Running,
+        formatter: "none",
+        serverVersion: "1.0.0",
+      };
       status = new YjitStatus(client);
     });
 
@@ -178,7 +192,13 @@ suite("StatusItems", () => {
   suite("YjitStatus when Ruby does not support it", () => {
     beforeEach(() => {
       ruby = { supportsYjit: false } as Ruby;
-      client = { context, ruby, state: ServerState.Running, formatter: "none" };
+      client = {
+        context,
+        ruby,
+        state: ServerState.Running,
+        formatter: "none",
+        serverVersion: "1.0.0",
+      };
       status = new YjitStatus(client);
     });
 
@@ -212,6 +232,7 @@ suite("StatusItems", () => {
         ruby,
         formatter,
         state: ServerState.Running,
+        serverVersion: "1.0.0",
       });
     });
 
@@ -267,6 +288,7 @@ suite("StatusItems", () => {
         ruby,
         state: ServerState.Running,
         formatter: "auto",
+        serverVersion: "1.0.0",
       };
       status = new FormatterStatus(client);
     });


### PR DESCRIPTION
### Motivation

Since many people don't have the Ruby LSP in their Gemfiles, it's hard to tell which version of the server they are running. We already have this information, so it's very easy to expose it.

### Implementation

Started showing the server version in the server status language item. We only show it if the server is running because the version is not available before then.

### Automated Tests

Adapted the existing tests.