### PR TITLE
Make tests pass locally

### DIFF
--- a/src/test/suite/client.test.ts
+++ b/src/test/suite/client.test.ts
@@ -6,7 +6,7 @@ import * as os from "os";
 import { afterEach } from "mocha";
 import * as vscode from "vscode";
 
-import { Ruby } from "../../ruby";
+import { Ruby, VersionManager } from "../../ruby";
 import { Telemetry, TelemetryApi, TelemetryEvent } from "../../telemetry";
 import { TestController } from "../../testController";
 import { ServerState } from "../../status";
@@ -31,6 +31,7 @@ suite("Client", () => {
   const managerConfig = vscode.workspace.getConfiguration("rubyLsp");
   const currentManager = managerConfig.get("rubyVersionManager");
   const tmpPath = fs.mkdtempSync(path.join(os.tmpdir(), "ruby-lsp-test-"));
+  fs.writeFileSync(path.join(tmpPath, ".ruby-version"), "3.2.2");
 
   afterEach(async () => {
     if (client && client.state === ServerState.Running) {
@@ -46,7 +47,16 @@ suite("Client", () => {
   });
 
   test("Starting up the server succeeds", async () => {
-    // await managerConfig.update("rubyVersionManager", "none", true, true);
+    // eslint-disable-next-line no-process-env
+    if (process.env.CI) {
+      await managerConfig.update(
+        "rubyVersionManager",
+        VersionManager.None,
+        true,
+        true,
+      );
+    }
+
     const context = {
       extensionMode: vscode.ExtensionMode.Test,
       subscriptions: [],

--- a/src/test/suite/telemetry.test.ts
+++ b/src/test/suite/telemetry.test.ts
@@ -50,6 +50,13 @@ suite("Telemetry", () => {
   });
 
   test("The API object is acquired via command", async () => {
+    // eslint-disable-next-line no-process-env
+    if (!process.env.CI) {
+      // This test can't pass locally because the private telemetry command is already registered. Trying to register it
+      // again always throws errors
+      return;
+    }
+
     const api = new FakeApi();
     vscode.commands.registerCommand(
       "ruby-lsp.getPrivateTelemetryApi",


### PR DESCRIPTION
### Motivation

Some of our tests were written in a way where they only passed on CI and not locally. That makes it difficult to verify changes and reduces the incentive to write more tests.

This PR makes all of our tests pass locally and skips one test that can't pass in local environments.