### PR TITLE
Allow configuring when to pull diagnostics

### DIFF
--- a/package.json
+++ b/package.json
@@ -249,6 +249,16 @@
           "description": "Run the Ruby LSP server from the specified branch rather than using the released gem. Only supported if not using bundleGemfile",
           "type": "string",
           "default": ""
+        },
+        "rubyLsp.pullDiagnosticsOn": {
+          "description": "When to pull diagnostics from the server (on change, save or both). Selecting save may significantly improve performance on large files",
+          "type": "string",
+          "enum": [
+            "change",
+            "save",
+            "both"
+          ],
+          "default": "both"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -251,7 +251,7 @@
           "default": ""
         },
         "rubyLsp.pullDiagnosticsOn": {
-          "description": "When to pull diagnostics from the server (on change, save or both). Selecting save may significantly improve performance on large files",
+          "description": "When to pull diagnostics from the server (on change, save or both). Selecting 'save' may significantly improve performance on large files",
           "type": "string",
           "enum": [
             "change",

--- a/src/client.ts
+++ b/src/client.ts
@@ -13,6 +13,7 @@ import {
   Range,
   ExecutableOptions,
   ServerOptions,
+  DiagnosticPullOptions,
 } from "vscode-languageclient/node";
 
 import { Telemetry } from "./telemetry";
@@ -91,6 +92,7 @@ export default class Client implements ClientInterface {
       diagnosticCollectionName: LSP_NAME,
       outputChannel: this.outputChannel,
       revealOutputChannelOn: RevealOutputChannelOn.Never,
+      diagnosticPullOptions: this.diagnosticPullOptions(),
       initializationOptions: {
         enabledFeatures: this.listOfEnabledFeatures(),
         experimentalFeaturesEnabled: configuration.get(
@@ -586,5 +588,16 @@ export default class Client implements ClientInterface {
 
   private hasUserDefinedCustomBundle(): boolean {
     return this.customBundleGemfile.length > 0;
+  }
+
+  private diagnosticPullOptions(): DiagnosticPullOptions {
+    const configuration = vscode.workspace.getConfiguration("rubyLsp");
+    const pullOn: "change" | "save" | "both" =
+      configuration.get("pullDiagnosticsOn")!;
+
+    return {
+      onChange: pullOn === "change" || pullOn === "both",
+      onSave: pullOn === "save" || pullOn === "both",
+    };
   }
 }


### PR DESCRIPTION
### Motivation

Closes https://github.com/Shopify/ruby-lsp/issues/963

I just realized this is significantly easier to implement than I originally thought. The client's now have the option to decide when to pull diagnostics: on change, on save or both.

That makes it super easy to make it configurable.

### Implementation

1. Added a new configuration to allow devs to decide when to pull diagnostics
2. Started passing `diagnosticPullOptions` to the client initialization

### Manual tests

1. Start the extension on this branch
2. Configure `"rubyLsp.pullDiagnosticsOn": "save"`
3. Verify changing a file doesn't show RuboCop diagnostics
4. Verify saving the file still fixes violations
5. If you add a violation that can't be auto-correct (like a super long line), verify that you still see diagnostics after save