### PR TITLE
Remove duplicate test runner commands, document keybindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,24 @@ Possible values are:
 - `messages`: display requests and responses notifications
 - `verbose`: display each request and response as JSON
 
+### Keybindings
+
+VS Code provides the default keybindings:
+
+| Command                        | Mac                 | Windows/Linux       |
+| ------------------------------ | ------------------- | ------------------- |
+| Test: Run Test At Cursor       | Command-; C         | Control-; C         |
+| Test: Rerun Last Run           | Command-; L         | Control-; L         |
+| Test: Rerun Failed Tests       | Command-; E         | Control-; E         |
+| Test: Run Test In Current File | Command-; F         | Control-; F         |
+| Test: Debug Test At Cursor     | Command-; Command-C | Control-; Control-C |
+
+In addition, the extension provides keybindings for:
+
+| Command                                | Mac           | Windows/Linux |
+| -------------------------------------- | ------------- | ------------- |
+| Ruby LSP: Run Current Test In Terminal | Ctrl-Option-I | Control-Alt-I |
+
 ### Debugging the server using VS Code
 
 The `launch.json` contains a 'Minitest - current file' configuration for the debugger.

--- a/package.json
+++ b/package.json
@@ -65,20 +65,8 @@
         "category": "Ruby LSP"
       },
       {
-        "command": "rubyLsp.runTest",
-        "title": "Run current test",
-        "category": "Ruby LSP",
-        "when": "editorActive && editorLangId == ruby"
-      },
-      {
         "command": "rubyLsp.runTestInTerminal",
         "title": "Run current test in terminal",
-        "category": "Ruby LSP",
-        "when": "editorActive && editorLangId == ruby"
-      },
-      {
-        "command": "rubyLsp.debugTest",
-        "title": "Debug current test",
         "category": "Ruby LSP",
         "when": "editorActive && editorLangId == ruby"
       },
@@ -86,6 +74,14 @@
         "command": "rubyLsp.showSyntaxTree",
         "title": "Show syntax tree",
         "category": "Ruby LSP"
+      }
+    ],
+    "keybindings": [
+      {
+        "command": "rubyLsp.runTestInTerminal",
+        "key": "ctrl+alt+i",
+        "mac": "ctrl+alt+i",
+        "when": "editorLangId == ruby"
       }
     ],
     "configuration": {

--- a/src/testController.ts
+++ b/src/testController.ts
@@ -72,8 +72,11 @@ export class TestController {
       this.testController,
       vscode.commands.registerCommand(
         Command.RunTest,
-        (_path, name, _command) => {
-          this.runOnClick(name);
+        (_path, _name, _command) => {
+          const line = vscode.window.activeTextEditor!.selection.active.line;
+          vscode.commands.executeCommand("testing.runAtCursor", {
+            lineNumber: line,
+          });
         },
       ),
       vscode.commands.registerCommand(
@@ -290,27 +293,6 @@ export class TestController {
         throw new Error(error.stdout);
       }
     }
-  }
-
-  private runOnClick(testId: string) {
-    const test = this.findTestById(testId);
-
-    if (!test) return;
-
-    vscode.commands.executeCommand("vscode.revealTestInExplorer", test);
-    let tokenSource: vscode.CancellationTokenSource | null =
-      new vscode.CancellationTokenSource();
-
-    tokenSource.token.onCancellationRequested(() => {
-      tokenSource?.dispose();
-      tokenSource = null;
-
-      vscode.window.showInformationMessage("Cancelled the progress");
-    });
-
-    const testRun = new vscode.TestRunRequest([test], [], this.testRunProfile);
-
-    this.testRunProfile.runHandler(testRun, tokenSource.token);
   }
 
   private findTestById(


### PR DESCRIPTION
### Motivation

Closes https://github.com/Shopify/vscode-ruby-lsp/issues/781, #717. Partially reverts #696.

### Implementation

Remove the redundant commands. Document the default keybindings.

I've kept the 'Run in Terminal' command for now until we decide what to about that.

### Automated Tests

None since we are using VS Code's built-in behaviour.

### Manual Tests

Run in debug mode and check against Ruby LSP.
