### PR TITLE
Create a CHANGELOG.md before publishing extension update

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,10 +22,22 @@ jobs:
         run: yarn --frozen-lockfile
 
       - name: Create CHANGELOG.md
-        run: |
-          RELEASE_NOTES=$(curl -L https://api.github.com/repos/Shopify/vscode-ruby-lsp/releases)
-          CHANGELOG=$(echo "$RELEASE_NOTES" | jq -r '.[] | "# \(.tag_name)", .body')
-          printf "%s\n" "$CHANGELOG" > CHANGELOG.md
+        uses: actions/github-script@v6
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          script: |
+            const fs = require("fs");
+
+            const { data: releases } = await github.rest.repos.listReleases({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+
+            const changelog = releases
+              .map((release) => `# ${release.tag_name}\n${release.body}\n`)
+              .join("\n");
+
+            fs.writeFileSync("CHANGELOG.md", changelog);
 
       # Stable releases
       - name: Publish extension in the marketplace

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,6 +21,12 @@ jobs:
       - name: 📦 Install dependencies
         run: yarn --frozen-lockfile
 
+      - name: Create CHANGELOG.md
+        run: |
+          RELEASE_NOTES=$(curl -L https://api.github.com/repos/Shopify/vscode-ruby-lsp/releases)
+          CHANGELOG=$(echo "$RELEASE_NOTES" | jq -r '.[] | "# \(.tag_name)", .body')
+          printf "%s\n" "$CHANGELOG" > CHANGELOG.md
+
       # Stable releases
       - name: Publish extension in the marketplace
         if: "!github.event.release.prerelease"


### PR DESCRIPTION
### Motivation

Closes #734 

The need is to create a `CHANGELOG.md` (without manual intervention) packaged into the extension publish.

### Implementation

- [Retrieve all releases](https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#list-releases) (including last one as this workflow is trigger after the release)
- Keep tag version and body (content of the release note) 
- Prepend a `#` before the tag to make a clear separation in the markdown between each release
- Insert this into a `CHANGELOG.md` at the root level as [required by the specification](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#marketplace-integration)

### Automated Tests

Impossible as I can't publish it myself.

### Manual Tests

I did a test, adding this code in the `ci.yml` workflow to check that everything goes as expected on push on my fork. 
Result is available here: https://github.com/snutij/vscode-ruby-lsp/actions/runs/6344046810/job/17233282072

- `ls` output show the root level with the `CHANGELOG.md` 
- cat `CHANGELOG.md` show the output well formatted

Note: we can see before each release note content this `<!-- Release notes generated using configuration in .github/release.yml at main -->` but we don't care as this is a comment it should not be displayed into vscode extension changelog tab.

I'll not copy-past output here, because it will link this PR to all PR already merged 😄