### PR TITLE
Add support for HAML syntax highlighting in Heredoc sections

### DIFF
--- a/grammars/ruby.cson.json
+++ b/grammars/ruby.cson.json
@@ -1557,6 +1557,44 @@
       ]
     },
     {
+      "begin": "(?=(?><<[-~]([\"'`]?)((?:[_\\w]+_|)HAML)\\b\\1))",
+      "comment": "Heredoc with embedded HAML",
+      "end": "(?!\\G)",
+      "name": "meta.embedded.block.haml",
+      "patterns": [
+        {
+          "begin": "(?><<[-~]([\"'`]?)((?:[_\\w]+_|)HAML)\\b\\1)",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.begin.ruby"
+            }
+          },
+          "contentName": "text.haml",
+          "end": "^\\s*\\2$\\n?",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.end.ruby"
+            }
+          },
+          "name": "string.unquoted.heredoc.ruby",
+          "patterns": [
+            {
+              "include": "#heredoc"
+            },
+            {
+              "include": "#interpolated_ruby"
+            },
+            {
+              "include": "text.haml"
+            },
+            {
+              "include": "#escaped_char"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "begin": "(?=(?><<[-~]([\"'`]?)((?:[_\\w]+_|)XML)\\b\\1))",
       "comment": "Heredoc with embedded XML",
       "end": "(?!\\G)",

--- a/src/test/suite/grammars.test.ts
+++ b/src/test/suite/grammars.test.ts
@@ -38,6 +38,10 @@ const EMBEDDED_HEREDOC_LANGUAGES: InferrableLanguageConfigOrLabel[] = [
     label: "C++",
   },
   {
+    label: "HAML",
+    contentName: "text.haml",
+  },
+  {
     label: "HTML",
     contentName: "text.html",
     includeName: "text.html.basic",


### PR DESCRIPTION
### Motivation

We have support for C++, JS, SQL, HTML, etc syntax highlighting in Heredoc, would be good to have it for HAML as well. Main use case for me is embedding HAML templates inline in ViewComponents. 

### Implementation

Copy/Pasted the HTML section.

### Automated Tests

None, the other Heredoc syntax highlighting don't seem to have any.

### Manual Tests
![image](https://github.com/Shopify/vscode-ruby-lsp/assets/1179/74b633f0-0a1e-47de-b031-88e430820f3a)

