### PR TITLE
Use sanitized parameters for telemetry

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -644,7 +644,7 @@ export default class Client implements ClientInterface {
         telemetryData.uri = uri;
       }
 
-      telemetryData.params = JSON.stringify(params);
+      telemetryData.params = JSON.stringify(castParam);
     }
 
     let result: T | undefined;


### PR DESCRIPTION
### Motivation

We were incorrectly passing the original parameters instead of the sanitized ones to telemetry.