### PR TITLE
Ignore initial requests from telemetry

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -621,8 +621,18 @@ export default class Client implements ClientInterface {
       return runRequest();
     }
 
+    const request = typeof type === "string" ? type : type.method;
+
+    // The first few requests are not representative for telemetry. Their response time is much higher than the rest
+    // because they are inflate by the time we spend indexing and by regular "warming up" of the server (like
+    // autoloading constants or running signature blocks).
+    if (this.requestId < 50) {
+      this.requestId++;
+      return runRequest();
+    }
+
     const telemetryData: RequestEvent = {
-      request: typeof type === "string" ? type : type.method,
+      request,
       rubyVersion: this.ruby.rubyVersion!,
       yjitEnabled: this.ruby.yjitEnabled!,
       lspVersion: this.serverVersion,


### PR DESCRIPTION
### Motivation

The initial requests are not representative of the performance of the LSP because they are initially blocked by indexing. Additionally, other things impact the measurement like autoloads or Sorbet unwrapping signatures.

### Implementation

Started returning early if the request id is below 50.