### PR TITLE
Add support for YAML HEREDOC highlighting

### DIFF
--- a/grammars/ruby.cson.json
+++ b/grammars/ruby.cson.json
@@ -1975,6 +1975,44 @@
       ]
     },
     {
+      "begin": "(?=(?><<[-~]([\"'`]?)((?:[_\\w]+_|)(?:YAML|YML))\\b\\1))",
+      "comment": "Heredoc with embedded YAML",
+      "end": "(?!\\G)",
+      "name": "meta.embedded.block.yaml",
+      "patterns": [
+        {
+          "begin": "(?><<[-~]([\"'`]?)((?:[_\\w]+_|)(?:YAML|YML))\\b\\1)",
+          "beginCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.begin.ruby"
+            }
+          },
+          "contentName": "source.yaml",
+          "end": "^\\s*\\2$\\n?",
+          "endCaptures": {
+            "0": {
+              "name": "punctuation.definition.string.end.ruby"
+            }
+          },
+          "name": "string.unquoted.heredoc.ruby",
+          "patterns": [
+            {
+              "include": "#heredoc"
+            },
+            {
+              "include": "#interpolated_ruby"
+            },
+            {
+              "include": "source.yaml"
+            },
+            {
+              "include": "#escaped_char"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "begin": "(?=(?><<[-~]([\"'`]?)((?:[_\\w]+_|)SLIM)\\b\\1))",
       "comment": "Heredoc with embedded Slim",
       "end": "(?!\\G)",

--- a/src/test/suite/grammars.test.ts
+++ b/src/test/suite/grammars.test.ts
@@ -66,6 +66,10 @@ const EMBEDDED_HEREDOC_LANGUAGES: InferrableLanguageConfigOrLabel[] = [
     label: "XML",
     contentName: "text.xml",
   },
+  {
+    label: "YAML",
+    delimiters: ["YAML", "YML"],
+  },
 ];
 
 // This file runs from inside the out/test directory


### PR DESCRIPTION
### Motivation

<!-- Closes # -->

<!-- Explain why you are making this change. Describe the problem being solved, not the solution. -->

This adds support for YAML syntax highlighting in HEREDOCs.

### Implementation

<!-- How did you implement your changes? Explain your solution, design decisions, things reviewers should watch out for. -->

TDD: The tests added in #842 were updated, and the config file was updated to make them pass.

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

TDD

### Manual Tests

<!-- Explain how we can test these changes in our own instance of VS Code. Provide the step by step instructions. -->

See the last column in this table.

<table>
<thead>
  <tr>
    <th colspan="2">GitHub</th>
    <th colspan="3">VSCode</th>
  </tr>
</thead>
<tbody>
  <tr>
    <td>Raw YAML</td>
    <td>HEREDOC</td>
    <td>Raw YAML</td>
    <td>HEREDOC Before</td>
    <td><strong>HEREDOC After<strong></td>
  </tr>
  <tr>
    <td>

```ruby
<<~YAML
foo:
  - [123, abc]
  - [true, "false"]
  - { xyz: null}
YAML
```

</td>
    <td>

```yaml
foo:
  - [123, abc]
  - [true, "false"]
  - { xyz: null}
```

</td>
    <td>
<img width="155" alt="image" src="https://github.com/Shopify/vscode-ruby-lsp/assets/8219340/8c59eb13-bd19-47bb-98e8-b45c54fc60a0">
</td>
    <td>
<img width="155" alt="image" src="https://github.com/Shopify/vscode-ruby-lsp/assets/8219340/fc1c01fc-7561-4bf5-8534-8c44b4dd1efe">
</td>
    <td>
<img width="153" alt="image" src="https://github.com/Shopify/vscode-ruby-lsp/assets/8219340/e598af23-c926-4bc3-a4bd-fbb1483aa3fd">
</td>
  </tr>
</tbody>
</table>

----

### Before Merging
- [x] Rebase after #842 is merged