### PR TITLE
Add more debugging logs

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -37,7 +37,7 @@ export default class Client implements ClientInterface {
   private readonly workingFolder: string;
   private readonly telemetry: Telemetry;
   private readonly statusItems: StatusItems;
-  private readonly outputChannel = vscode.window.createOutputChannel(LSP_NAME);
+  private readonly outputChannel: vscode.OutputChannel;
   private readonly testController: TestController;
   private readonly customBundleGemfile: string = vscode.workspace
     .getConfiguration("rubyLsp")
@@ -56,6 +56,7 @@ export default class Client implements ClientInterface {
     telemetry: Telemetry,
     ruby: Ruby,
     testController: TestController,
+    outputChannel: vscode.OutputChannel,
     workingFolder = vscode.workspace.workspaceFolders![0].uri.fsPath,
   ) {
     this.workingFolder = workingFolder;
@@ -64,6 +65,7 @@ export default class Client implements ClientInterface {
     this.testController = testController;
     this.#context = context;
     this.#ruby = ruby;
+    this.outputChannel = outputChannel;
     this.#formatter = "";
     this.statusItems = new StatusItems(this);
     this.registerCommands();

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -16,13 +16,16 @@ export class Debugger
   private debugProcess?: ChildProcessWithoutNullStreams;
   private readonly console = vscode.debug.activeDebugConsole;
   private readonly subscriptions: vscode.Disposable[];
+  private readonly outputChannel: vscode.OutputChannel;
 
   constructor(
     context: vscode.ExtensionContext,
     ruby: Ruby,
+    outputChannel: vscode.OutputChannel,
     workingFolder = vscode.workspace.workspaceFolders![0].uri.fsPath,
   ) {
     this.ruby = ruby;
+    this.outputChannel = outputChannel;
     this.subscriptions = [
       vscode.debug.registerDebugConfigurationProvider("ruby_lsp", this),
       vscode.debug.registerDebugAdapterDescriptorFactory("ruby_lsp", this),
@@ -130,7 +133,11 @@ export class Debugger
     // eslint-disable-next-line @typescript-eslint/no-misused-promises
     return new Promise((resolve, reject) => {
       if (sockets.length === 0) {
-        reject(new Error("No debuggee processes found"));
+        reject(
+          new Error(
+            `No debuggee processes found. Was a socket created in ${socketsDir}?`,
+          ),
+        );
       }
 
       return vscode.window
@@ -161,23 +168,31 @@ export class Debugger
     const configuration = session.configuration;
 
     return new Promise((resolve, reject) => {
-      this.debugProcess = spawn(
-        "bundle",
-        [
-          "exec",
-          "rdbg",
-          "--open",
-          "--command",
-          `--sock-path=${sockPath}`,
-          "--",
-          configuration.program,
-        ],
-        {
-          shell: true,
-          env: configuration.env,
-          cwd: this.workingFolder,
-        },
+      const args = [
+        "exec",
+        "rdbg",
+        "--open",
+        "--command",
+        `--sock-path=${sockPath}`,
+        "--",
+        configuration.program,
+      ];
+
+      this.outputChannel.appendLine(
+        `Ruby LSP> Spawning debugger in directory ${this.workingFolder}`,
       );
+      this.outputChannel.appendLine(
+        `Ruby LSP>   Command bundle ${args.join(" ")}`,
+      );
+      this.outputChannel.appendLine(
+        `Ruby LSP>   Environment ${JSON.stringify(configuration.env)}`,
+      );
+
+      this.debugProcess = spawn("bundle", args, {
+        shell: true,
+        env: configuration.env,
+        cwd: this.workingFolder,
+      });
 
       this.debugProcess.stderr.on("data", (data) => {
         const message = data.toString();
@@ -214,8 +229,9 @@ export class Debugger
       // actually an error
       this.debugProcess.on("exit", (code) => {
         if (code) {
-          const message = `Debugger exited with status ${code}`;
+          const message = `Debugger exited with status ${code}. Check the output channel for more information`;
           this.console.append(message);
+          this.outputChannel.show();
           reject(new Error(message));
         }
       });

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -229,7 +229,7 @@ export class Debugger
       // actually an error
       this.debugProcess.on("exit", (code) => {
         if (code) {
-          const message = `Debugger exited with status ${code}. Check the output channel for more information`;
+          const message = `Debugger exited with status ${code}. Check the output channel for more information.`;
           this.console.append(message);
           this.outputChannel.show();
           reject(new Error(message));

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,7 +12,8 @@ let debug: Debugger | undefined;
 let testController: TestController | undefined;
 
 export async function activate(context: vscode.ExtensionContext) {
-  const ruby = new Ruby(context);
+  const outputChannel = vscode.window.createOutputChannel("Ruby LSP");
+  const ruby = new Ruby(context, outputChannel);
   await ruby.activateRuby();
 
   const telemetry = new Telemetry(context);
@@ -25,10 +26,10 @@ export async function activate(context: vscode.ExtensionContext) {
     telemetry,
   );
 
-  client = new Client(context, telemetry, ruby, testController);
+  client = new Client(context, telemetry, ruby, testController, outputChannel);
 
   await client.start();
-  debug = new Debugger(context, ruby);
+  debug = new Debugger(context, ruby, outputChannel);
 
   vscode.workspace.registerTextDocumentContentProvider(
     "ruby-lsp",

--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -30,13 +30,16 @@ export class Ruby {
   private _error = false;
   private readonly context: vscode.ExtensionContext;
   private readonly customBundleGemfile?: string;
+  private readonly outputChannel: vscode.OutputChannel;
 
   constructor(
     context: vscode.ExtensionContext,
+    outputChannel: vscode.OutputChannel,
     workingFolder = vscode.workspace.workspaceFolders![0].uri.fsPath,
   ) {
     this.context = context;
     this.workingFolder = workingFolder;
+    this.outputChannel = outputChannel;
 
     const customBundleGemfile: string = vscode.workspace
       .getConfiguration("rubyLsp")
@@ -75,6 +78,9 @@ export class Ruby {
     // If the version manager is auto, discover the actual manager before trying to activate anything
     if (this.versionManager === VersionManager.Auto) {
       await this.discoverVersionManager();
+      this.outputChannel.appendLine(
+        `Ruby LSP> Discovered version manager ${this.versionManager}`,
+      );
     }
 
     try {
@@ -167,6 +173,10 @@ export class Ruby {
     const cwd = this.customBundleGemfile
       ? path.dirname(this.customBundleGemfile)
       : this.workingFolder;
+
+    this.outputChannel.appendLine(
+      `Ruby LSP> Trying to activate Ruby environment with command: ${command} inside directory: ${cwd}`,
+    );
 
     const result = await asyncExec(command, { cwd });
 
@@ -302,6 +312,10 @@ export class Ruby {
       if (this.shell) {
         command += "'";
       }
+
+      this.outputChannel.appendLine(
+        `Ruby LSP> Checking if ${tool} is available on the path with command: ${command}`,
+      );
 
       await asyncExec(command, { cwd: this.workingFolder });
       return true;

--- a/src/test/suite/client.test.ts
+++ b/src/test/suite/client.test.ts
@@ -28,6 +28,7 @@ class FakeApi implements TelemetryApi {
 suite("Client", () => {
   let client: Client | undefined;
   let testController: TestController | undefined;
+  const outputChannel = vscode.window.createOutputChannel("Ruby LSP");
   const managerConfig = vscode.workspace.getConfiguration("rubyLsp");
   const currentManager = managerConfig.get("rubyVersionManager");
   const tmpPath = fs.mkdtempSync(path.join(os.tmpdir(), "ruby-lsp-test-"));
@@ -66,7 +67,7 @@ suite("Client", () => {
       },
     } as unknown as vscode.ExtensionContext;
 
-    const ruby = new Ruby(context, tmpPath);
+    const ruby = new Ruby(context, outputChannel, tmpPath);
     await ruby.activateRuby();
 
     const telemetry = new Telemetry(context, new FakeApi());
@@ -83,6 +84,7 @@ suite("Client", () => {
       telemetry,
       ruby,
       testController,
+      outputChannel,
       tmpPath,
     );
     await client.start();

--- a/src/test/suite/debugger.test.ts
+++ b/src/test/suite/debugger.test.ts
@@ -9,10 +9,12 @@ import { Debugger } from "../../debugger";
 import { Ruby } from "../../ruby";
 
 suite("Debugger", () => {
+  const outputChannel = vscode.window.createOutputChannel("Ruby LSP");
+
   test("Provide debug configurations returns the default configs", () => {
     const context = { subscriptions: [] } as unknown as vscode.ExtensionContext;
     const ruby = { env: {} } as Ruby;
-    const debug = new Debugger(context, ruby, "fake");
+    const debug = new Debugger(context, ruby, outputChannel, "fake");
     const configs = debug.provideDebugConfigurations!(undefined);
     assert.deepEqual(
       [
@@ -45,7 +47,7 @@ suite("Debugger", () => {
   test("Resolve configuration injects Ruby environment", () => {
     const context = { subscriptions: [] } as unknown as vscode.ExtensionContext;
     const ruby = { env: { bogus: "hello!" } } as unknown as Ruby;
-    const debug = new Debugger(context, ruby, "fake");
+    const debug = new Debugger(context, ruby, outputChannel, "fake");
     const configs: any = debug.resolveDebugConfiguration!(undefined, {
       type: "ruby_lsp",
       name: "Debug",
@@ -61,7 +63,7 @@ suite("Debugger", () => {
   test("Resolve configuration injects Ruby environment and allows users custom environment", () => {
     const context = { subscriptions: [] } as unknown as vscode.ExtensionContext;
     const ruby = { env: { bogus: "hello!" } } as unknown as Ruby;
-    const debug = new Debugger(context, ruby, "fake");
+    const debug = new Debugger(context, ruby, outputChannel, "fake");
     const configs: any = debug.resolveDebugConfiguration!(undefined, {
       type: "ruby_lsp",
       name: "Debug",
@@ -82,7 +84,7 @@ suite("Debugger", () => {
 
     const context = { subscriptions: [] } as unknown as vscode.ExtensionContext;
     const ruby = { env: { bogus: "hello!" } } as unknown as Ruby;
-    const debug = new Debugger(context, ruby, tmpPath);
+    const debug = new Debugger(context, ruby, outputChannel, tmpPath);
     const configs: any = debug.resolveDebugConfiguration!(undefined, {
       type: "ruby_lsp",
       name: "Debug",

--- a/src/test/suite/ruby.test.ts
+++ b/src/test/suite/ruby.test.ts
@@ -21,7 +21,11 @@ suite("Ruby environment activation", () => {
       extensionMode: vscode.ExtensionMode.Test,
     } as vscode.ExtensionContext;
 
-    ruby = new Ruby(context, tmpPath);
+    ruby = new Ruby(
+      context,
+      vscode.window.createOutputChannel("Ruby LSP"),
+      tmpPath,
+    );
     await ruby.activateRuby(
       // eslint-disable-next-line no-process-env
       process.env.CI ? VersionManager.None : VersionManager.Chruby,


### PR DESCRIPTION
### Motivation

Closes #829
Improves #832 a bit

As more people begin to use the extension, we're subject to a new variety of configurations and environments and it's often hard to tell what's going without detailed information. I think we need to log more in the extension, so that debugging complex setups is easier.

### Implementation

Started sharing the output channel between our main objects and then printed a bunch of logs to it. It should help diagnose issues more easily.

Are there any other things we should be logging?