### PR TITLE
Pass experimental flag as CLI argument to the server

### DIFF
--- a/package.json
+++ b/package.json
@@ -251,11 +251,6 @@
           "type": "integer",
           "default": 30
         },
-        "rubyLsp.branch": {
-          "description": "Run the Ruby LSP server from the specified branch rather than using the released gem. Only supported if not using bundleGemfile",
-          "type": "string",
-          "default": ""
-        },
         "rubyLsp.pullDiagnosticsOn": {
           "description": "When to pull diagnostics from the server (on change, save or both). Selecting 'save' may significantly improve performance on large files",
           "type": "string",

--- a/src/client.ts
+++ b/src/client.ts
@@ -562,9 +562,9 @@ export default class Client implements ClientInterface {
   private executables(): ServerOptions {
     let run: Executable;
     let debug: Executable;
-    const branch: string = vscode.workspace
+    const experimental: boolean = vscode.workspace
       .getConfiguration("rubyLsp")
-      .get("branch")!;
+      .get("enableExperimentalFeatures")!;
 
     const executableOptions: ExecutableOptions = {
       cwd: this.workingFolder,
@@ -589,7 +589,7 @@ export default class Client implements ClientInterface {
     } else {
       run = {
         command: "ruby-lsp",
-        args: branch.length > 0 ? ["--branch", branch] : [],
+        args: experimental ? ["--experimental"] : [],
         options: executableOptions,
       };
 


### PR DESCRIPTION
### Motivation

Client side of https://github.com/Shopify/ruby-lsp/pull/1126.

Get rid of the branch configuration and use `experimental` instead to install beta versions of the server gem.

### Implementation

Started passing the `--experimental` flag to the server.