### PR TITLE
Allow using `gems.rb` and `gems.locked`

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   ],
   "activationEvents": [
     "onLanguage:ruby",
-    "workspaceContains:Gemfile.lock"
+    "workspaceContains:Gemfile.lock",
+    "workspaceContains:gems.locked"
   ],
   "main": "./out/extension.js",
   "contributes": {

--- a/src/client.ts
+++ b/src/client.ts
@@ -345,6 +345,7 @@ export default class Client implements ClientInterface {
 
   private registerAutoRestarts() {
     this.createRestartWatcher("Gemfile.lock");
+    this.createRestartWatcher("gems.locked");
     this.createRestartWatcher("**/.rubocop.yml");
 
     // If a configuration that affects the Ruby LSP has changed, update the client options using the latest
@@ -467,6 +468,12 @@ export default class Client implements ClientInterface {
       fs.existsSync(path.join(this.workingFolder, ".ruby-lsp", "Gemfile"))
     ) {
       bundleGemfile = path.join(this.workingFolder, ".ruby-lsp", "Gemfile");
+    } else if (
+      fs.existsSync(path.join(this.workingFolder, ".ruby-lsp", "gems.rb"))
+    ) {
+      bundleGemfile = path.join(this.workingFolder, ".ruby-lsp", "gems.rb");
+    } else if (fs.existsSync(path.join(this.workingFolder, "gems.rb"))) {
+      bundleGemfile = path.join(this.workingFolder, "gems.rb");
     } else {
       bundleGemfile = path.join(this.workingFolder, "Gemfile");
     }

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -101,11 +101,16 @@ export class Debugger
       debugConfiguration.env = this.ruby.env;
     }
 
-    const customGemfilePath = path.join(
+    let customGemfilePath = path.join(
       this.workingFolder,
       ".ruby-lsp",
       "Gemfile",
     );
+    if (fs.existsSync(customGemfilePath)) {
+      debugConfiguration.env.BUNDLE_GEMFILE = customGemfilePath;
+    }
+
+    customGemfilePath = path.join(this.workingFolder, ".ruby-lsp", "gems.rb");
     if (fs.existsSync(customGemfilePath)) {
       debugConfiguration.env.BUNDLE_GEMFILE = customGemfilePath;
     }


### PR DESCRIPTION
### Motivation

Second part of https://github.com/Shopify/ruby-lsp/issues/1137

There are a few places where we need to take the `gems.rb` into account to fully support it.

**Note**: I'm hardcoding the `gems.rb` and `gems.locked` files here. I don't think other gemfile names are common enough to justify spawning a process to ask Bundler what the right name is.

### Implementation

Just accounted for the `gems.rb` and `gems.locked` files.