### PR TITLE
Show an error if VS Code doesn't have permission to write on the working folder

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -78,6 +78,19 @@ export default class Client implements ClientInterface {
       return;
     }
 
+    try {
+      fs.accessSync(this.workingFolder, fs.constants.W_OK);
+    } catch (error: any) {
+      this.state = ServerState.Error;
+
+      vscode.window.showErrorMessage(
+        `Directory ${this.workingFolder} is not writable. The Ruby LSP server needs to be able to create a .ruby-lsp
+        directory to function appropriately. Consider switching to a directory for which VS Code has write permissions`,
+      );
+
+      return;
+    }
+
     this.state = ServerState.Starting;
 
     try {


### PR DESCRIPTION
### Motivation

Closes #863

If the extension is started in a directory for which VS Code has no write permissions, the server will fail to create the `.ruby-lsp` directory and won't boot properly.

Long term, I believe the solution might be to move the `.ruby-lsp` directories from inside projects to be all under a `~/.ruby-lsp` directory. For the time being, I think we can just show an error to let the user know what's happening.

### Implementation

Checked if the current directory is writable and then returned early if it's not.