### PR TITLE
Avoid printing to stdout from Client or Ruby activation

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -432,13 +432,13 @@ export default class Client implements ClientInterface {
       "rubyLsp.lastGemUpdate",
     );
 
-    const { stdout } = await asyncExec("gem list ruby-lsp", {
+    const { stderr } = await asyncExec("gem list ruby-lsp 1>&2", {
       cwd: this.workingFolder,
       env: this.ruby.env,
     });
 
     // If the gem is not yet installed, install it
-    if (!stdout.includes("ruby-lsp")) {
+    if (!stderr.includes("ruby-lsp")) {
       await asyncExec("gem install ruby-lsp", {
         cwd: this.workingFolder,
         env: this.ruby.env,
@@ -492,14 +492,14 @@ export default class Client implements ClientInterface {
     }
 
     const result = await asyncExec(
-      `bundle exec ruby -e "require 'ruby-lsp'; print RubyLsp::VERSION"`,
+      `bundle exec ruby -e "require 'ruby-lsp'; STDERR.print(RubyLsp::VERSION)"`,
       {
         cwd: this.workingFolder,
         env: { ...this.ruby.env, BUNDLE_GEMFILE: bundleGemfile },
       },
     );
 
-    return result.stdout;
+    return result.stderr;
   }
 
   // If the `.git` folder exists and `.git/rebase-merge` or `.git/rebase-apply` exists, then we're in the middle of a


### PR DESCRIPTION
### Motivation

This may be the solution for #850.

I suspect the issue is that RVM is somehow causing something to be printed to STDOUT, which is basically left in the pipe until the LSP starts. When it finally does start, it reads STDOUT and gets the stuff that was printed, which is invalid from the LSP's perspective.

I'm not 100% sure this is the fix, but in general we should simply never use `STDOUT` or `STDIN` for anything when it comes to the client, because it may mess up the client-server communication. 

### Implementation

I switched all places in `Client` and `Ruby` where we were using STDOUT to get versions or perform activation. We now rely only on STDERR, which in LSPs is only used for printing and not for communication.