### PR TITLE
Alert shadowenv users about missing Ruby

### DIFF
--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -150,6 +150,16 @@ export class Ruby {
     // eslint-disable-next-line no-process-env
     const env = { ...process.env, ...JSON.parse(result.stderr).exported };
 
+    // If the configurations under `.shadowenv.d/` point to a Ruby version that is not installed, shadowenv will still
+    // return the complete environment without throwing any errors. Here, we check to see if the RUBY_ROOT returned by
+    // shadowenv exists. If it doens't, then it's likely that the Ruby version configured is not installed
+    if (!fs.existsSync(env.RUBY_ROOT)) {
+      throw new Error(
+        `The Ruby version configured in .shadowenv.d is ${env.RUBY_VERSION}, \
+        but the Ruby installation at ${env.RUBY_ROOT} does not exist`,
+      );
+    }
+
     // The only reason we set the process environment here is to allow other extensions that don't perform activation
     // work properly
     // eslint-disable-next-line no-process-env


### PR DESCRIPTION
### Motivation

If the files under the `.shadowenv.d` directory are configured with a Ruby version that is not installed in the machine, shadowenv does not throw any errors. Instead, it returns the "activated" environment, pointing to a bunch of paths that don't actually exist.

That can be very confusing for users, so we should let them know that something is not right.

### Implementation

Started checking if the `RUBY_ROOT` configured exists. If that directory is missing, then either the Ruby version isn't installed or it was installed elsewhere. In both cases, the solution is to re-generate the files under `.shadowenv.d` with the right paths.