### PR TITLE
Refactor `Ruby` and output channel

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -1,0 +1,17 @@
+import fs from "fs/promises";
+import { exec } from "child_process";
+import { promisify } from "util";
+
+export const asyncExec = promisify(exec);
+
+export async function pathExists(
+  path: string,
+  mode = fs.constants.R_OK,
+): Promise<boolean> {
+  try {
+    await fs.access(path, mode);
+    return true;
+  } catch (error: any) {
+    return false;
+  }
+}

--- a/src/common.ts
+++ b/src/common.ts
@@ -2,7 +2,12 @@ import fs from "fs/promises";
 import { exec } from "child_process";
 import { promisify } from "util";
 
+import * as vscode from "vscode";
+
 export const asyncExec = promisify(exec);
+export const LOG_CHANNEL = vscode.window.createOutputChannel("Ruby LSP", {
+  log: true,
+});
 
 export async function pathExists(
   path: string,

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -5,6 +5,7 @@ import { ChildProcessWithoutNullStreams, spawn } from "child_process";
 import * as vscode from "vscode";
 
 import { Ruby } from "./ruby";
+import { LOG_CHANNEL } from "./common";
 
 export class Debugger
   implements
@@ -16,16 +17,13 @@ export class Debugger
   private debugProcess?: ChildProcessWithoutNullStreams;
   private readonly console = vscode.debug.activeDebugConsole;
   private readonly subscriptions: vscode.Disposable[];
-  private readonly outputChannel: vscode.OutputChannel;
 
   constructor(
     context: vscode.ExtensionContext,
     ruby: Ruby,
-    outputChannel: vscode.OutputChannel,
     workingFolder = vscode.workspace.workspaceFolders![0].uri.fsPath,
   ) {
     this.ruby = ruby;
-    this.outputChannel = outputChannel;
     this.subscriptions = [
       vscode.debug.registerDebugConfigurationProvider("ruby_lsp", this),
       vscode.debug.registerDebugAdapterDescriptorFactory("ruby_lsp", this),
@@ -183,15 +181,9 @@ export class Debugger
         configuration.program,
       ];
 
-      this.outputChannel.appendLine(
-        `Ruby LSP> Spawning debugger in directory ${this.workingFolder}`,
-      );
-      this.outputChannel.appendLine(
-        `Ruby LSP>   Command bundle ${args.join(" ")}`,
-      );
-      this.outputChannel.appendLine(
-        `Ruby LSP>   Environment ${JSON.stringify(configuration.env)}`,
-      );
+      LOG_CHANNEL.info(`Spawning debugger in directory ${this.workingFolder}`);
+      LOG_CHANNEL.info(`   Command bundle ${args.join(" ")}`);
+      LOG_CHANNEL.info(`   Environment ${JSON.stringify(configuration.env)}`);
 
       this.debugProcess = spawn("bundle", args, {
         shell: true,
@@ -236,7 +228,7 @@ export class Debugger
         if (code) {
           const message = `Debugger exited with status ${code}. Check the output channel for more information.`;
           this.console.append(message);
-          this.outputChannel.show();
+          LOG_CHANNEL.show();
           reject(new Error(message));
         }
       });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,10 +12,8 @@ let debug: Debugger | undefined;
 let testController: TestController | undefined;
 
 export async function activate(context: vscode.ExtensionContext) {
-  const outputChannel = vscode.window.createOutputChannel("Ruby LSP");
   const ruby = new Ruby(
     context,
-    outputChannel,
     vscode.workspace.workspaceFolders![0].uri.fsPath,
   );
   await ruby.activateRuby();
@@ -30,10 +28,10 @@ export async function activate(context: vscode.ExtensionContext) {
     telemetry,
   );
 
-  client = new Client(context, telemetry, ruby, testController, outputChannel);
+  client = new Client(context, telemetry, ruby, testController);
 
   await client.start();
-  debug = new Debugger(context, ruby, outputChannel);
+  debug = new Debugger(context, ruby);
 
   vscode.workspace.registerTextDocumentContentProvider(
     "ruby-lsp",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -13,7 +13,11 @@ let testController: TestController | undefined;
 
 export async function activate(context: vscode.ExtensionContext) {
   const outputChannel = vscode.window.createOutputChannel("Ruby LSP");
-  const ruby = new Ruby(context, outputChannel);
+  const ruby = new Ruby(
+    context,
+    outputChannel,
+    vscode.workspace.workspaceFolders![0].uri.fsPath,
+  );
   await ruby.activateRuby();
 
   const telemetry = new Telemetry(context);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,10 +12,7 @@ let debug: Debugger | undefined;
 let testController: TestController | undefined;
 
 export async function activate(context: vscode.ExtensionContext) {
-  const ruby = new Ruby(
-    context,
-    vscode.workspace.workspaceFolders![0].uri.fsPath,
-  );
+  const ruby = new Ruby(context, vscode.workspace.workspaceFolders![0]);
   await ruby.activateRuby();
 
   const telemetry = new Telemetry(context);

--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -3,7 +3,7 @@ import fs from "fs/promises";
 
 import * as vscode from "vscode";
 
-import { asyncExec, pathExists } from "./common";
+import { asyncExec, pathExists, LOG_CHANNEL } from "./common";
 
 export enum VersionManager {
   Asdf = "asdf",
@@ -29,16 +29,10 @@ export class Ruby {
   private readonly context: vscode.ExtensionContext;
   private readonly customBundleGemfile?: string;
   private readonly cwd: string;
-  private readonly outputChannel: vscode.OutputChannel;
 
-  constructor(
-    context: vscode.ExtensionContext,
-    outputChannel: vscode.OutputChannel,
-    workingFolder: string,
-  ) {
+  constructor(context: vscode.ExtensionContext, workingFolder: string) {
     this.context = context;
     this.workingFolder = workingFolder;
-    this.outputChannel = outputChannel;
 
     const customBundleGemfile: string = vscode.workspace
       .getConfiguration("rubyLsp")
@@ -81,9 +75,7 @@ export class Ruby {
     // If the version manager is auto, discover the actual manager before trying to activate anything
     if (this.versionManager === VersionManager.Auto) {
       await this.discoverVersionManager();
-      this.outputChannel.appendLine(
-        `Ruby LSP> Discovered version manager ${this.versionManager}`,
-      );
+      LOG_CHANNEL.info(`Discovered version manager ${this.versionManager}`);
     }
 
     try {
@@ -189,8 +181,8 @@ export class Ruby {
       command += "'";
     }
 
-    this.outputChannel.appendLine(
-      `Ruby LSP> Trying to activate Ruby environment with command: ${command} inside directory: ${this.cwd}`,
+    LOG_CHANNEL.info(
+      `Trying to activate Ruby environment with command: ${command} inside directory: ${this.cwd}`,
     );
 
     const result = await asyncExec(command, { cwd: this.cwd });
@@ -323,8 +315,8 @@ export class Ruby {
         command += "'";
       }
 
-      this.outputChannel.appendLine(
-        `Ruby LSP> Checking if ${tool} is available on the path with command: ${command}`,
+      LOG_CHANNEL.info(
+        `Checking if ${tool} is available on the path with command: ${command}`,
       );
 
       await asyncExec(command, { cwd: this.workingFolder, timeout: 1000 });

--- a/src/test/suite/client.test.ts
+++ b/src/test/suite/client.test.ts
@@ -66,7 +66,9 @@ suite("Client", () => {
       },
     } as unknown as vscode.ExtensionContext;
 
-    const ruby = new Ruby(context, tmpPath);
+    const ruby = new Ruby(context, {
+      uri: { fsPath: tmpPath },
+    } as vscode.WorkspaceFolder);
     await ruby.activateRuby();
 
     const telemetry = new Telemetry(context, new FakeApi());

--- a/src/test/suite/client.test.ts
+++ b/src/test/suite/client.test.ts
@@ -28,7 +28,6 @@ class FakeApi implements TelemetryApi {
 suite("Client", () => {
   let client: Client | undefined;
   let testController: TestController | undefined;
-  const outputChannel = vscode.window.createOutputChannel("Ruby LSP");
   const managerConfig = vscode.workspace.getConfiguration("rubyLsp");
   const currentManager = managerConfig.get("rubyVersionManager");
   const tmpPath = fs.mkdtempSync(path.join(os.tmpdir(), "ruby-lsp-test-"));
@@ -67,7 +66,7 @@ suite("Client", () => {
       },
     } as unknown as vscode.ExtensionContext;
 
-    const ruby = new Ruby(context, outputChannel, tmpPath);
+    const ruby = new Ruby(context, tmpPath);
     await ruby.activateRuby();
 
     const telemetry = new Telemetry(context, new FakeApi());
@@ -84,7 +83,6 @@ suite("Client", () => {
       telemetry,
       ruby,
       testController,
-      outputChannel,
       tmpPath,
     );
     await client.start();

--- a/src/test/suite/debugger.test.ts
+++ b/src/test/suite/debugger.test.ts
@@ -9,12 +9,10 @@ import { Debugger } from "../../debugger";
 import { Ruby } from "../../ruby";
 
 suite("Debugger", () => {
-  const outputChannel = vscode.window.createOutputChannel("Ruby LSP");
-
   test("Provide debug configurations returns the default configs", () => {
     const context = { subscriptions: [] } as unknown as vscode.ExtensionContext;
     const ruby = { env: {} } as Ruby;
-    const debug = new Debugger(context, ruby, outputChannel, "fake");
+    const debug = new Debugger(context, ruby, "fake");
     const configs = debug.provideDebugConfigurations!(undefined);
     assert.deepEqual(
       [
@@ -47,7 +45,7 @@ suite("Debugger", () => {
   test("Resolve configuration injects Ruby environment", () => {
     const context = { subscriptions: [] } as unknown as vscode.ExtensionContext;
     const ruby = { env: { bogus: "hello!" } } as unknown as Ruby;
-    const debug = new Debugger(context, ruby, outputChannel, "fake");
+    const debug = new Debugger(context, ruby, "fake");
     const configs: any = debug.resolveDebugConfiguration!(undefined, {
       type: "ruby_lsp",
       name: "Debug",
@@ -63,7 +61,7 @@ suite("Debugger", () => {
   test("Resolve configuration injects Ruby environment and allows users custom environment", () => {
     const context = { subscriptions: [] } as unknown as vscode.ExtensionContext;
     const ruby = { env: { bogus: "hello!" } } as unknown as Ruby;
-    const debug = new Debugger(context, ruby, outputChannel, "fake");
+    const debug = new Debugger(context, ruby, "fake");
     const configs: any = debug.resolveDebugConfiguration!(undefined, {
       type: "ruby_lsp",
       name: "Debug",
@@ -84,7 +82,7 @@ suite("Debugger", () => {
 
     const context = { subscriptions: [] } as unknown as vscode.ExtensionContext;
     const ruby = { env: { bogus: "hello!" } } as unknown as Ruby;
-    const debug = new Debugger(context, ruby, outputChannel, tmpPath);
+    const debug = new Debugger(context, ruby, tmpPath);
     const configs: any = debug.resolveDebugConfiguration!(undefined, {
       type: "ruby_lsp",
       name: "Debug",

--- a/src/test/suite/ruby.test.ts
+++ b/src/test/suite/ruby.test.ts
@@ -21,11 +21,7 @@ suite("Ruby environment activation", () => {
       extensionMode: vscode.ExtensionMode.Test,
     } as vscode.ExtensionContext;
 
-    ruby = new Ruby(
-      context,
-      vscode.window.createOutputChannel("Ruby LSP"),
-      tmpPath,
-    );
+    ruby = new Ruby(context, tmpPath);
     await ruby.activateRuby(
       // eslint-disable-next-line no-process-env
       process.env.CI ? VersionManager.None : VersionManager.Chruby,

--- a/src/test/suite/ruby.test.ts
+++ b/src/test/suite/ruby.test.ts
@@ -21,7 +21,9 @@ suite("Ruby environment activation", () => {
       extensionMode: vscode.ExtensionMode.Test,
     } as vscode.ExtensionContext;
 
-    ruby = new Ruby(context, tmpPath);
+    ruby = new Ruby(context, {
+      uri: { fsPath: tmpPath },
+    } as vscode.WorkspaceFolder);
     await ruby.activateRuby(
       // eslint-disable-next-line no-process-env
       process.env.CI ? VersionManager.None : VersionManager.Chruby,


### PR DESCRIPTION
### Motivation

I think there are a few opportunities to improve the code quality in our extension, make it easier to test and better prepare to support #381.

This PR makes some refactors on `Ruby` and our output channel.

### Implementation

I recommend reviewing by commit.

For `Ruby`, there are basically three changes:

- Started requiring the workspace folder path (preparation for #381)
- Switched to using async file checks everywhere
- Started avoiding a second shell out to Ruby for fetching `RUBY_VERSION` and YJIT information. The only version manager where this is not possible is `shadowenv`, which has a different activation mechanism. For `shadowenv`, we continue doing the same

For the output channel, the changes are:

- Making it a log channel. This works basically like a Rails logger and is much nicer than what we had before. It includes timestamps and log level
- Put it in a constant, since the channel has no dependencies and we want every part of the extension to always reuse the same one

Started putting common functionality in a `common.ts` file. I will follow up with some more refactors that will likely move more stuff in there and simplify the existing classes. 

### Automated Tests

Fixed tests where necessary.