### PR TITLE
Escape spaces in shell path

### DIFF
--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -23,7 +23,7 @@ export class Ruby {
   private readonly workingFolderPath: string;
   #versionManager?: VersionManager;
   // eslint-disable-next-line no-process-env
-  private readonly shell = process.env.SHELL;
+  private readonly shell = process.env.SHELL?.replace(/(\s+)/g, "\\$1");
   private _env: NodeJS.ProcessEnv = {};
   private _error = false;
   private readonly context: vscode.ExtensionContext;


### PR DESCRIPTION
### Motivation

Closes #883

If the shell path has spaces in it, we need to escape them. I don't think we can just wrap the path in quotes, because we had reports of the quotes breaking shell execution on Windows.

### Implementation

Used replace with a regex to switch spaces for their escaped version. The regex has a capture group for any sequence of at least one space and then substitutes it for a backslash with the contents of the captured group.

In other words, it just takes all of the spaces and puts a `\` in front.