### PR TITLE
Refactor extension and allow for multiple workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "ruby-lsp",
   "displayName": "Ruby LSP",
   "description": "VS Code plugin for connecting with the Ruby LSP",
-  "version": "0.4.22",
+  "version": "0.5.2",
   "publisher": "Shopify",
   "repository": {
     "type": "git",

--- a/src/common.ts
+++ b/src/common.ts
@@ -3,9 +3,53 @@ import { exec } from "child_process";
 import { promisify } from "util";
 
 import * as vscode from "vscode";
+import { State } from "vscode-languageclient";
+
+export enum Command {
+  Start = "rubyLsp.start",
+  Stop = "rubyLsp.stop",
+  Restart = "rubyLsp.restart",
+  Update = "rubyLsp.update",
+  ToggleExperimentalFeatures = "rubyLsp.toggleExperimentalFeatures",
+  ServerOptions = "rubyLsp.serverOptions",
+  ToggleYjit = "rubyLsp.toggleYjit",
+  SelectVersionManager = "rubyLsp.selectRubyVersionManager",
+  ToggleFeatures = "rubyLsp.toggleFeatures",
+  FormatterHelp = "rubyLsp.formatterHelp",
+  RunTest = "rubyLsp.runTest",
+  RunTestInTerminal = "rubyLsp.runTestInTerminal",
+  DebugTest = "rubyLsp.debugTest",
+  OpenLink = "rubyLsp.openLink",
+  ShowSyntaxTree = "rubyLsp.showSyntaxTree",
+}
+
+export interface RubyInterface {
+  error: boolean;
+  versionManager?: string;
+  rubyVersion?: string;
+  supportsYjit?: boolean;
+}
+
+export interface ClientInterface {
+  state: State;
+  formatter: string;
+  serverVersion?: string;
+}
+
+export interface WorkspaceInterface {
+  ruby: RubyInterface;
+  lspClient?: ClientInterface;
+  error: boolean;
+}
+
+// Event emitter used to signal that the language status items need to be refreshed
+export const STATUS_EMITTER = new vscode.EventEmitter<
+  WorkspaceInterface | undefined
+>();
 
 export const asyncExec = promisify(exec);
-export const LOG_CHANNEL = vscode.window.createOutputChannel("Ruby LSP", {
+export const LSP_NAME = "Ruby LSP";
+export const LOG_CHANNEL = vscode.window.createOutputChannel(LSP_NAME, {
   log: true,
 });
 

--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -3,7 +3,7 @@ import fs from "fs/promises";
 
 import * as vscode from "vscode";
 
-import { asyncExec, pathExists, LOG_CHANNEL } from "./common";
+import { asyncExec, pathExists, LOG_CHANNEL, RubyInterface } from "./common";
 
 export enum VersionManager {
   Asdf = "asdf",
@@ -16,7 +16,7 @@ export enum VersionManager {
   Custom = "custom",
 }
 
-export class Ruby {
+export class Ruby implements RubyInterface {
   public rubyVersion?: string;
   public yjitEnabled?: boolean;
   public supportsYjit?: boolean;

--- a/src/rubyLsp.ts
+++ b/src/rubyLsp.ts
@@ -1,0 +1,402 @@
+import path from "path";
+
+import * as vscode from "vscode";
+import { Range } from "vscode-languageclient/node";
+
+import { Telemetry } from "./telemetry";
+import DocumentProvider from "./documentProvider";
+import { Workspace } from "./workspace";
+import { Command, STATUS_EMITTER, pathExists } from "./common";
+import { VersionManager } from "./ruby";
+import { StatusItems } from "./status";
+import { TestController } from "./testController";
+import { Debugger } from "./debugger";
+
+// The RubyLsp class represents an instance of the entire extension. This should only be instantiated once at the
+// activation event. One instance of this class controls all of the existing workspaces, telemetry and handles all
+// commands
+export class RubyLsp {
+  private readonly workspaces: Map<string, Workspace> = new Map();
+  private readonly telemetry: Telemetry;
+  private readonly context: vscode.ExtensionContext;
+  private readonly statusItems: StatusItems;
+  private readonly testController: TestController;
+  private readonly debug: Debugger;
+
+  constructor(context: vscode.ExtensionContext) {
+    this.context = context;
+    this.telemetry = new Telemetry(context);
+    this.testController = new TestController(
+      context,
+      this.telemetry,
+      this.currentActiveWorkspace.bind(this),
+    );
+    this.debug = new Debugger(context, this.currentActiveWorkspace.bind(this));
+    this.registerCommands(context);
+
+    this.statusItems = new StatusItems();
+    context.subscriptions.push(this.statusItems, this.debug);
+
+    // Switch the status items based on which workspace is currently active
+    vscode.window.onDidChangeActiveTextEditor((editor) => {
+      STATUS_EMITTER.fire(this.currentActiveWorkspace(editor));
+    });
+
+    vscode.workspace.onDidChangeWorkspaceFolders(async (event) => {
+      // Stop the language server and dispose all removed workspaces
+      for (const workspaceFolder of event.removed) {
+        const workspace = this.getWorkspace(workspaceFolder.uri);
+
+        if (workspace) {
+          await workspace.stop();
+          await workspace.dispose();
+          this.workspaces.delete(workspaceFolder.uri.toString());
+        }
+      }
+
+      // Create and activate new workspaces for the added folders
+      for (const workspaceFolder of event.added) {
+        await this.activateWorkspace(workspaceFolder);
+      }
+    });
+
+    // Lazily activate workspaces that do not contain a lockfile
+    vscode.workspace.onDidOpenTextDocument(async (document) => {
+      if (document.languageId !== "ruby") {
+        return;
+      }
+
+      const workspaceFolder = vscode.workspace.getWorkspaceFolder(document.uri);
+
+      if (!workspaceFolder) {
+        return;
+      }
+
+      const workspace = this.getWorkspace(workspaceFolder.uri);
+
+      // If the workspace entry doesn't exist, then we haven't activated the workspace yet
+      if (!workspace) {
+        await this.activateWorkspace(workspaceFolder);
+      }
+    });
+  }
+
+  // Activate the extension. This method should perform all actions necessary to start the extension, such as booting
+  // all language servers for each existing workspace
+  async activate() {
+    await this.telemetry.sendConfigurationEvents();
+
+    for (const workspaceFolder of vscode.workspace.workspaceFolders!) {
+      await this.activateWorkspace(workspaceFolder);
+    }
+
+    this.context.subscriptions.push(
+      vscode.workspace.registerTextDocumentContentProvider(
+        "ruby-lsp",
+        new DocumentProvider(),
+      ),
+    );
+
+    STATUS_EMITTER.fire(this.currentActiveWorkspace());
+  }
+
+  // Deactivate the extension, which should stop all language servers. Notice that this just stops anything that is
+  // running, but doesn't dispose of existing instances
+  async deactivate() {
+    for (const workspace of this.workspaces.values()) {
+      await workspace.stop();
+    }
+  }
+
+  private async activateWorkspace(workspaceFolder: vscode.WorkspaceFolder) {
+    const workspaceDir = workspaceFolder.uri.fsPath;
+
+    // If one of the workspaces does not contain a lockfile, then we don't try to start a language server. If the user
+    // ends up opening a Ruby file inside that workspace, then we lazily activate the workspace. These need to match our
+    // `workspaceContains` activation events in package.json
+    if (
+      !(await pathExists(path.join(workspaceDir, "Gemfile.lock"))) &&
+      !(await pathExists(path.join(workspaceDir, "gems.locked")))
+    ) {
+      return;
+    }
+
+    const workspace = new Workspace(
+      this.context,
+      workspaceFolder,
+      this.telemetry,
+      this.testController.createTestItems.bind(this.testController),
+    );
+    this.workspaces.set(workspaceFolder.uri.toString(), workspace);
+
+    await workspace.start();
+    this.context.subscriptions.push(workspace);
+  }
+
+  // Registers all extension commands. Commands can only be registered once, so this happens in the constructor. For
+  // creating multiple instances in tests, the `RubyLsp` object should be disposed of after each test to prevent double
+  // command register errors
+  private registerCommands(context: vscode.ExtensionContext) {
+    context.subscriptions.push(
+      vscode.commands.registerCommand(Command.Update, async () => {
+        const workspace = await this.showWorkspacePick();
+        await workspace?.installOrUpdateServer();
+      }),
+      vscode.commands.registerCommand(Command.Start, async () => {
+        const workspace = await this.showWorkspacePick();
+        await workspace?.start();
+      }),
+      vscode.commands.registerCommand(Command.Restart, async () => {
+        const workspace = await this.showWorkspacePick();
+        await workspace?.restart();
+      }),
+      vscode.commands.registerCommand(Command.Stop, async () => {
+        const workspace = await this.showWorkspacePick();
+        await workspace?.stop();
+      }),
+      vscode.commands.registerCommand(
+        Command.OpenLink,
+        async (link: string) => {
+          vscode.env.openExternal(vscode.Uri.parse(link));
+
+          const workspace = this.currentActiveWorkspace();
+
+          if (workspace?.lspClient?.serverVersion) {
+            await this.telemetry.sendCodeLensEvent(
+              "link",
+              workspace.lspClient.serverVersion,
+            );
+          }
+        },
+      ),
+      vscode.commands.registerCommand(
+        Command.ShowSyntaxTree,
+        this.showSyntaxTree.bind(this),
+      ),
+      vscode.commands.registerCommand(Command.FormatterHelp, () => {
+        vscode.env.openExternal(
+          vscode.Uri.parse(
+            "https://github.com/Shopify/vscode-ruby-lsp#formatting",
+          ),
+        );
+      }),
+      vscode.commands.registerCommand(Command.ToggleFeatures, async () => {
+        // Extract feature descriptions from our package.json
+        const enabledFeaturesProperties =
+          vscode.extensions.getExtension("Shopify.ruby-lsp")!.packageJSON
+            .contributes.configuration.properties["rubyLsp.enabledFeatures"]
+            .properties;
+
+        const descriptions: { [key: string]: string } = {};
+        Object.entries(enabledFeaturesProperties).forEach(
+          ([key, value]: [string, any]) => {
+            descriptions[key] = value.description;
+          },
+        );
+
+        const configuration = vscode.workspace.getConfiguration("rubyLsp");
+        const features: { [key: string]: boolean } =
+          configuration.get("enabledFeatures")!;
+        const allFeatures = Object.keys(features);
+        const options: vscode.QuickPickItem[] = allFeatures.map((label) => {
+          return {
+            label,
+            picked: features[label],
+            description: descriptions[label],
+          };
+        });
+
+        const toggledFeatures = await vscode.window.showQuickPick(options, {
+          canPickMany: true,
+          placeHolder: "Select the features you would like to enable",
+        });
+
+        if (toggledFeatures !== undefined) {
+          // The `picked` property is only used to determine if the checkbox is checked initially. When we receive the
+          // response back from the QuickPick, we need to use inclusion to check if the feature was selected
+          allFeatures.forEach((feature) => {
+            features[feature] = toggledFeatures.some(
+              (selected) => selected.label === feature,
+            );
+          });
+
+          await vscode.workspace
+            .getConfiguration("rubyLsp")
+            .update("enabledFeatures", features, true, true);
+        }
+      }),
+      vscode.commands.registerCommand(Command.ToggleYjit, () => {
+        const lspConfig = vscode.workspace.getConfiguration("rubyLsp");
+        const yjitEnabled = lspConfig.get("yjit");
+        lspConfig.update("yjit", !yjitEnabled, true, true);
+
+        const workspace = this.currentActiveWorkspace();
+
+        if (workspace) {
+          STATUS_EMITTER.fire(workspace);
+        }
+      }),
+      vscode.commands.registerCommand(
+        Command.ToggleExperimentalFeatures,
+        async () => {
+          const lspConfig = vscode.workspace.getConfiguration("rubyLsp");
+          const experimentalFeaturesEnabled = lspConfig.get(
+            "enableExperimentalFeatures",
+          );
+          await lspConfig.update(
+            "enableExperimentalFeatures",
+            !experimentalFeaturesEnabled,
+            true,
+            true,
+          );
+
+          STATUS_EMITTER.fire(this.currentActiveWorkspace());
+        },
+      ),
+      vscode.commands.registerCommand(
+        Command.ServerOptions,
+        async (options: [{ label: string; description: string }]) => {
+          const result = await vscode.window.showQuickPick(options, {
+            placeHolder: "Select server action",
+          });
+
+          if (result !== undefined)
+            await vscode.commands.executeCommand(result.description);
+        },
+      ),
+      vscode.commands.registerCommand(
+        Command.SelectVersionManager,
+        async () => {
+          const configuration = vscode.workspace.getConfiguration("rubyLsp");
+          const options = Object.values(VersionManager);
+          const manager = await vscode.window.showQuickPick(options, {
+            placeHolder: `Current: ${configuration.get("rubyVersionManager")}`,
+          });
+
+          if (manager !== undefined) {
+            configuration.update("rubyVersionManager", manager, true, true);
+          }
+        },
+      ),
+      vscode.commands.registerCommand(
+        Command.RunTest,
+        (_path, name, _command) => {
+          this.testController.runOnClick(name);
+        },
+      ),
+      vscode.commands.registerCommand(
+        Command.RunTestInTerminal,
+        this.testController.runTestInTerminal.bind(this.testController),
+      ),
+      vscode.commands.registerCommand(
+        Command.DebugTest,
+        this.testController.debugTest.bind(this.testController),
+      ),
+    );
+  }
+
+  // Get the current active workspace based on which file is opened in the editor
+  private currentActiveWorkspace(
+    activeEditor = vscode.window.activeTextEditor,
+  ): Workspace | undefined {
+    if (!activeEditor) {
+      return;
+    }
+
+    const document = activeEditor.document;
+    const workspaceFolder = vscode.workspace.getWorkspaceFolder(document.uri);
+
+    if (!workspaceFolder) {
+      return;
+    }
+
+    return this.getWorkspace(workspaceFolder.uri);
+  }
+
+  private getWorkspace(uri: vscode.Uri): Workspace | undefined {
+    return this.workspaces.get(uri.toString());
+  }
+
+  // Displays a quick pick to select which workspace to perform an action on. For example, if multiple workspaces exist,
+  // then we need to know which workspace to restart the language server on
+  private async showWorkspacePick(): Promise<Workspace | undefined> {
+    if (this.workspaces.size === 1) {
+      return this.workspaces.values().next().value;
+    }
+
+    const workspaceFolder = await vscode.window.showWorkspaceFolderPick();
+
+    if (!workspaceFolder) {
+      return;
+    }
+
+    return this.getWorkspace(workspaceFolder.uri);
+  }
+
+  // Show syntax tree command
+  private async showSyntaxTree() {
+    const activeEditor = vscode.window.activeTextEditor;
+
+    if (activeEditor) {
+      const document = activeEditor.document;
+
+      if (document.languageId !== "ruby") {
+        vscode.window.showErrorMessage("Show syntax tree: not a Ruby file");
+        return;
+      }
+
+      const workspaceFolder = vscode.workspace.getWorkspaceFolder(document.uri);
+
+      if (!workspaceFolder) {
+        return;
+      }
+
+      const workspace = this.getWorkspace(workspaceFolder.uri);
+
+      const selection = activeEditor.selection;
+      let range: Range | undefined;
+
+      // Anchor is the first point and active is the last point in the selection. If both are the same, nothing is
+      // selected
+      if (!selection.active.isEqual(selection.anchor)) {
+        // If you start selecting from below and go up, then the selection is reverted
+        if (selection.isReversed) {
+          range = Range.create(
+            selection.active.line,
+            selection.active.character,
+            selection.anchor.line,
+            selection.anchor.character,
+          );
+        } else {
+          range = Range.create(
+            selection.anchor.line,
+            selection.anchor.character,
+            selection.active.line,
+            selection.active.character,
+          );
+        }
+      }
+
+      const response: { ast: string } | null | undefined =
+        await workspace?.lspClient?.sendShowSyntaxTreeRequest(
+          document.uri,
+          range,
+        );
+
+      if (response) {
+        const document = await vscode.workspace.openTextDocument(
+          vscode.Uri.from({
+            scheme: "ruby-lsp",
+            path: "show-syntax-tree",
+            query: response.ast,
+          }),
+        );
+
+        await vscode.window.showTextDocument(document, {
+          viewColumn: vscode.ViewColumn.Beside,
+          preserveFocus: true,
+        });
+      }
+    }
+  }
+}

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -41,7 +41,6 @@ class DevelopmentApi implements TelemetryApi {
 }
 
 export class Telemetry {
-  public serverVersion?: string;
   private api?: TelemetryApi;
   private readonly context: vscode.ExtensionContext;
 
@@ -110,8 +109,8 @@ export class Telemetry {
     );
   }
 
-  async sendCodeLensEvent(type: CodeLensEvent["type"]) {
-    await this.sendEvent({ type, lspVersion: this.serverVersion! });
+  async sendCodeLensEvent(type: CodeLensEvent["type"], lspVersion: string) {
+    await this.sendEvent({ type, lspVersion });
   }
 
   private async initialize(): Promise<boolean> {

--- a/src/test/suite/client.test.ts
+++ b/src/test/suite/client.test.ts
@@ -5,12 +5,12 @@ import * as os from "os";
 
 import { afterEach } from "mocha";
 import * as vscode from "vscode";
+import { State } from "vscode-languageclient/node";
 
 import { Ruby, VersionManager } from "../../ruby";
 import { Telemetry, TelemetryApi, TelemetryEvent } from "../../telemetry";
-import { TestController } from "../../testController";
-import { ServerState } from "../../status";
 import Client from "../../client";
+import { asyncExec } from "../../common";
 
 class FakeApi implements TelemetryApi {
   public sentEvents: TelemetryEvent[];
@@ -27,19 +27,20 @@ class FakeApi implements TelemetryApi {
 
 suite("Client", () => {
   let client: Client | undefined;
-  let testController: TestController | undefined;
   const managerConfig = vscode.workspace.getConfiguration("rubyLsp");
   const currentManager = managerConfig.get("rubyVersionManager");
   const tmpPath = fs.mkdtempSync(path.join(os.tmpdir(), "ruby-lsp-test-"));
+  const workspaceFolder: vscode.WorkspaceFolder = {
+    uri: vscode.Uri.parse(`file://${tmpPath}`),
+    name: path.basename(tmpPath),
+    index: 0,
+  };
   fs.writeFileSync(path.join(tmpPath, ".ruby-version"), "3.2.2");
 
   afterEach(async () => {
-    if (client && client.state === ServerState.Running) {
+    if (client && client.state === State.Running) {
       await client.stop();
-    }
-
-    if (testController) {
-      testController.dispose();
+      await client.dispose();
     }
 
     managerConfig.update("rubyVersionManager", currentManager, true, true);
@@ -66,28 +67,23 @@ suite("Client", () => {
       },
     } as unknown as vscode.ExtensionContext;
 
-    const ruby = new Ruby(context, {
-      uri: { fsPath: tmpPath },
-    } as vscode.WorkspaceFolder);
+    const ruby = new Ruby(context, workspaceFolder);
     await ruby.activateRuby();
 
+    await asyncExec("gem install ruby-lsp", {
+      cwd: workspaceFolder.uri.fsPath,
+      env: ruby.env,
+    });
+
     const telemetry = new Telemetry(context, new FakeApi());
-
-    const testController = new TestController(
-      context,
-      tmpPath,
-      ruby,
-      telemetry,
-    );
-
     const client = new Client(
       context,
       telemetry,
       ruby,
-      testController,
-      tmpPath,
+      () => {},
+      workspaceFolder,
     );
     await client.start();
-    assert.strictEqual(client.state, ServerState.Running);
+    assert.strictEqual(client.state, State.Running);
   }).timeout(30000);
 });

--- a/src/test/suite/telemetry.test.ts
+++ b/src/test/suite/telemetry.test.ts
@@ -121,8 +121,7 @@ suite("Telemetry", () => {
       api,
     );
 
-    telemetry.serverVersion = "1.0.0";
-    await telemetry.sendCodeLensEvent("test");
+    await telemetry.sendCodeLensEvent("test", "1.0.0");
 
     const codeLensEvent = api.sentEvents[0] as CodeLensEvent;
     assert.strictEqual(codeLensEvent.type, "test");

--- a/src/workspace.ts
+++ b/src/workspace.ts
@@ -1,0 +1,245 @@
+import fs from "fs/promises";
+import path from "path";
+
+import * as vscode from "vscode";
+import { CodeLens } from "vscode-languageclient/node";
+
+import { Ruby } from "./ruby";
+import { Telemetry } from "./telemetry";
+import Client from "./client";
+import {
+  asyncExec,
+  LOG_CHANNEL,
+  WorkspaceInterface,
+  STATUS_EMITTER,
+  pathExists,
+} from "./common";
+
+export class Workspace implements WorkspaceInterface {
+  public lspClient?: Client;
+  public readonly ruby: Ruby;
+  public readonly createTestItems: (response: CodeLens[]) => void;
+  public readonly workspaceFolder: vscode.WorkspaceFolder;
+  private readonly context: vscode.ExtensionContext;
+  private readonly telemetry: Telemetry;
+  #error = false;
+
+  constructor(
+    context: vscode.ExtensionContext,
+    workspaceFolder: vscode.WorkspaceFolder,
+    telemetry: Telemetry,
+    createTestItems: (response: CodeLens[]) => void,
+  ) {
+    this.context = context;
+    this.workspaceFolder = workspaceFolder;
+    this.telemetry = telemetry;
+    this.ruby = new Ruby(context, workspaceFolder);
+    this.createTestItems = createTestItems;
+
+    this.registerRestarts(context);
+  }
+
+  async start() {
+    await this.ruby.activateRuby();
+
+    if (this.ruby.error) {
+      this.error = true;
+      return;
+    }
+
+    try {
+      await fs.access(this.workspaceFolder.uri.fsPath, fs.constants.W_OK);
+    } catch (error: any) {
+      this.error = true;
+
+      vscode.window.showErrorMessage(
+        `Directory ${this.workspaceFolder.uri.fsPath} is not writable. The Ruby LSP server needs to be able to create a
+        .ruby-lsp directory to function appropriately. Consider switching to a directory for which VS Code has write
+        permissions`,
+      );
+
+      return;
+    }
+
+    try {
+      await this.installOrUpdateServer();
+    } catch (error: any) {
+      this.error = true;
+      vscode.window.showErrorMessage(
+        `Failed to setup the bundle: ${error.message}. \
+            See [Troubleshooting](https://github.com/Shopify/vscode-ruby-lsp#troubleshooting) for instructions`,
+      );
+
+      return;
+    }
+
+    // The `start` method can be invoked through commands - even if there's an LSP client already running. We need to
+    // ensure that the existing client for this workspace has been stopped and disposed of before we create a new one
+    if (this.lspClient) {
+      await this.lspClient.stop();
+      await this.lspClient.dispose();
+    }
+
+    this.lspClient = new Client(
+      this.context,
+      this.telemetry,
+      this.ruby,
+      this.createTestItems,
+      this.workspaceFolder,
+    );
+
+    try {
+      STATUS_EMITTER.fire(this);
+      await this.lspClient.start();
+      this.lspClient.performAfterStart();
+      STATUS_EMITTER.fire(this);
+    } catch (error: any) {
+      this.error = true;
+      LOG_CHANNEL.error(`Error starting the server: ${error.message}`);
+    }
+  }
+
+  async stop() {
+    await this.lspClient?.stop();
+  }
+
+  async restart() {
+    try {
+      if (await this.rebaseInProgress()) {
+        return;
+      }
+
+      if (this.lspClient) {
+        await this.stop();
+        await this.lspClient.dispose();
+        await this.start();
+      } else {
+        await this.start();
+      }
+    } catch (error: any) {
+      this.error = true;
+      LOG_CHANNEL.error(`Error restarting the server: ${error.message}`);
+    }
+  }
+
+  async dispose() {
+    await this.lspClient?.dispose();
+  }
+
+  // Install or update the `ruby-lsp` gem globally with `gem install ruby-lsp` or `gem update ruby-lsp`. We only try to
+  // update on a daily basis, not every time the server boots
+  async installOrUpdateServer(): Promise<void> {
+    // If there's a user configured custom bundle to run the LSP, then we do not perform auto-updates and let the user
+    // manage that custom bundle themselves
+    const customBundle: string = vscode.workspace
+      .getConfiguration("rubyLsp")
+      .get("bundleGemfile")!;
+
+    if (customBundle.length > 0) {
+      return;
+    }
+
+    const oneDayInMs = 24 * 60 * 60 * 1000;
+    const lastUpdatedAt: number | undefined = this.context.workspaceState.get(
+      "rubyLsp.lastGemUpdate",
+    );
+
+    const { stderr } = await asyncExec("gem list ruby-lsp 1>&2", {
+      cwd: this.workspaceFolder.uri.fsPath,
+      env: this.ruby.env,
+    });
+
+    // If the gem is not yet installed, install it
+    if (!stderr.includes("ruby-lsp")) {
+      await asyncExec("gem install ruby-lsp", {
+        cwd: this.workspaceFolder.uri.fsPath,
+        env: this.ruby.env,
+      });
+
+      this.context.workspaceState.update("rubyLsp.lastGemUpdate", Date.now());
+      return;
+    }
+
+    // If we haven't updated the gem in the last 24 hours, update it
+    if (
+      lastUpdatedAt === undefined ||
+      Date.now() - lastUpdatedAt > oneDayInMs
+    ) {
+      try {
+        await asyncExec("gem update ruby-lsp", {
+          cwd: this.workspaceFolder.uri.fsPath,
+          env: this.ruby.env,
+        });
+        this.context.workspaceState.update("rubyLsp.lastGemUpdate", Date.now());
+      } catch (error) {
+        // If we fail to update the global installation of `ruby-lsp`, we don't want to prevent the server from starting
+        LOG_CHANNEL.error(`Failed to update global ruby-lsp gem: ${error}`);
+      }
+    }
+  }
+
+  get error() {
+    return this.#error;
+  }
+
+  private set error(value: boolean) {
+    STATUS_EMITTER.fire(this);
+    this.#error = value;
+  }
+
+  private registerRestarts(context: vscode.ExtensionContext) {
+    this.createRestartWatcher(context, "Gemfile.lock");
+    this.createRestartWatcher(context, "gems.locked");
+    this.createRestartWatcher(context, "**/.rubocop.yml");
+
+    // If a configuration that affects the Ruby LSP has changed, update the client options using the latest
+    // configuration and restart the server
+    vscode.workspace.onDidChangeConfiguration(async (event) => {
+      if (event.affectsConfiguration("rubyLsp")) {
+        // Re-activate Ruby if the version manager changed
+        if (
+          event.affectsConfiguration("rubyLsp.rubyVersionManager") ||
+          event.affectsConfiguration("rubyLsp.bundleGemfile") ||
+          event.affectsConfiguration("rubyLsp.customRubyCommand")
+        ) {
+          await this.ruby.activateRuby();
+        }
+
+        await this.restart();
+      }
+    });
+  }
+
+  private createRestartWatcher(
+    context: vscode.ExtensionContext,
+    pattern: string,
+  ) {
+    const watcher = vscode.workspace.createFileSystemWatcher(
+      new vscode.RelativePattern(this.workspaceFolder.uri.fsPath, pattern),
+    );
+    context.subscriptions.push(watcher);
+
+    watcher.onDidChange(this.restart.bind(this));
+    watcher.onDidCreate(this.restart.bind(this));
+    watcher.onDidDelete(this.restart.bind(this));
+  }
+
+  // If the `.git` folder exists and `.git/rebase-merge` or `.git/rebase-apply` exists, then we're in the middle of a
+  // rebase
+  private async rebaseInProgress() {
+    const gitFolder = path.join(this.workspaceFolder.uri.fsPath, ".git");
+
+    if (!(await pathExists(gitFolder))) {
+      return false;
+    }
+
+    if (
+      (await pathExists(path.join(gitFolder, "rebase-merge"))) ||
+      (await pathExists(path.join(gitFolder, "rebase-apply")))
+    ) {
+      return true;
+    }
+
+    return false;
+  }
+}


### PR DESCRIPTION
### Motivation

Closes #381

This pull request is a massive refactor to decouple many concepts in our codebase. The ultimate goals are to better separate concerns, make things easier to test and allow for multiple workspace support.

[Here's the multi-workspace server sample as a reference](https://github.com/microsoft/vscode-extension-samples/tree/main/lsp-multi-server-sample).

### Implementation

The commits are somewhat organized, but it's not a perfect story as I kept hitting more and more issues and had to make changes to fix them. I'll instead explain how the codebase is organized.

- `RubyLsp`: this class represents the entire extension. It owns everything in the extension and controls the top level activation and deactivation. It has a map of workspaces, where each workspace uri points to a `Workspace` instance. Since commands can only be registered once, this class now owns every single command in the extension
- `Workspace`: this class represents a single workspace. It owns the LSP client and the Ruby environment, since each workspace may use different Ruby versions and different dependencies. It's this class' responsibility to activate the Ruby environment, the language server, install the server gem and register restart watchers
- `Ruby`: not many changes here. Each instance of this class represents a Ruby environment activation for a given workspace
- `TestController`: the extension should only have a single test controller, so this class is owned by `RubyLsp`. Its only dependencies are figuring out what workspace it should be running the tests on (because it needs the current working directory and the Ruby environment). We inject a function from `RubyLsp` to allow the controller to select the current workspace
- `Debug`: similar to `TestController`, the extension should only register one debugger client. It uses the same technique of injecting the function to select the current workspace, so that we know the current working directory and the Ruby environment
- `Client`: the client has been refactored to inherit from `LanguageClient`, rather than using the previous decorator pattern by keeping a `client` property. This allows us to have direct access to the client's properties, like state (which is why our own implementation of state was removed)
- `StatusItems`: the recommendation of the VS Code docs is that the language status items should always display the relevant information for the current file, since the items are dependent on which file is opened. Therefore, `RubyLsp` owns the items and refreshes them using an event emitter any time the workspace changes. That allows us to display the workspace-specific information
- `Telemetry`: the only change in telemetry is that it no longer owns the server version. We need that in the `Client`, since each client could be running a different server version

### Automated Tests

This PR is already absolutely immense, so I will follow up with other PRs to add better tests.

### Manual Tests

#### Single workspace

1. Start the extension on this branch
2. Open a single repository
3. Make sure the following are working
    - Ruby LSP features like diagnostics, formatting, document symbol, etc
    - Start, restart, stop commands
    - Show syntax tree command
    - Run, run in terminal and debug code lens
    - Status items showing the right information. All status items' commands working

#### Multi workspace

1. Start the extension on this branch
2. Open a single repository
3. Click `File` -> `Add folder to workspace`
4. Add a different folder to the current workspace. I recommend using `ruby-lsp` and `tapioca`, so that you can see the different Ruby versions in the status items
5. Make sure the following are working for both workspaces
    - Ruby LSP features like diagnostics, formatting, document symbol, etc
    - Start, restart, stop commands
    - Show syntax tree command
    - Run, run in terminal and debug code lens
    - Status items showing the right information. All status items' commands working