### PR TITLE
Add setting to test Bundler compose

### DIFF
--- a/package.json
+++ b/package.json
@@ -266,6 +266,11 @@
             "both"
           ],
           "default": "both"
+        },
+        "rubyLsp.useBundlerCompose": {
+          "description": "This is a temporary setting for testing purposes, do not use it! Replace the custom bundle logic by bundler-compose.",
+          "type": "boolean",
+          "default": false
         }
       }
     },

--- a/src/client.ts
+++ b/src/client.ts
@@ -29,12 +29,10 @@ function getLspExecutables(
 ): ServerOptions {
   let run: Executable;
   let debug: Executable;
-  const branch: string = vscode.workspace
-    .getConfiguration("rubyLsp")
-    .get("branch")!;
-  const customBundleGemfile: string = vscode.workspace
-    .getConfiguration("rubyLsp")
-    .get("bundleGemfile")!;
+  const config = vscode.workspace.getConfiguration("rubyLsp");
+  const branch: string = config.get("branch")!;
+  const customBundleGemfile: string = config.get("bundleGemfile")!;
+  const useBundlerCompose: boolean = config.get("useBundlerCompose")!;
 
   const executableOptions: ExecutableOptions = {
     cwd: workspaceFolder.uri.fsPath,
@@ -54,6 +52,18 @@ function getLspExecutables(
     debug = {
       command: "bundle",
       args: ["exec", "ruby-lsp", "--debug"],
+      options: executableOptions,
+    };
+  } else if (useBundlerCompose) {
+    run = {
+      command: "bundle",
+      args: ["compose", "gem", "ruby-lsp"],
+      options: executableOptions,
+    };
+
+    debug = {
+      command: "bundle",
+      args: ["compose", "gem", "ruby-lsp", "--", "--debug"],
       options: executableOptions,
     };
   } else {


### PR DESCRIPTION
### Motivation

Our custom bundle logic doesn't work super smoothly on every development environment. [Bundler-compose](https://github.com/segiddins/bundler-compose) is the correct way to go, which uses the right Bundler internals to achieve what we need. The goal is also to incorporate it into Bundler eventually.

For the time being, it still has some rough edges that need ironing out, so I'd like to add a temporary setting for us to test Bundler-compose easily. That way we can provide feedback to the bundler team and eventually get rid of our custom bundle logic, which should hopefully remove a lot of support workload.

Once this is battle tested, then we would update `ruby-lsp` and `debug` using `gem update ruby-lsp debug` from the extension and we'd always run commands using `bundle compose`.

### Implementation

Just added a setting and changed the executable to be `bundle compose gem ruby-lsp` when it's turned on.

This does not affect our custom bundle logic in any way, because when we run it with bundler-compose it sets `BUNDLE_GEMFILE` and our logic is skipped.