### PR TITLE
Fix in/when dedent with language configuration

### DIFF
--- a/languages/ruby.json
+++ b/languages/ruby.json
@@ -1,0 +1,5 @@
+{
+  "indentationRules": {
+    "decreaseIndentPattern": "^\\s*([}\\]]([,)]?\\s*(#|$)|\\.[a-zA-Z_]\\w*\\b)|(end|rescue|ensure|else|elsif)\\b)|((in|when)\\s)"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -381,7 +381,8 @@
           "capfile",
           "rakefile",
           "gemfile"
-        ]
+        ],
+        "configuration": "./languages/ruby.json"
       },
       {
         "id": "erb",


### PR DESCRIPTION
### Motivation

Fixes part of #828

The issue with the indentation is the Ruby language configuration defined inside VS Code itself. We can expose a configuration to fix it temporarily, but we will upstream this to VS Code itself so that we don't have to bundle one.

### Implementation

Instead of decreasing the indentation on `in|when`, we only decrease on `(in|when)\s` which waits for a single space to do it. That way, things like `include` will never match and not reduce the indendation.