### PR TITLE
Remove newlines from Ruby activation script

### DIFF
--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -169,8 +169,16 @@ export class Ruby {
 
   private async activate(ruby: string) {
     let command = this.shell ? `${this.shell} -ic '` : "";
-    command += `${ruby} -rjson -e "STDERR.printf(%{RUBY_ENV_ACTIVATE%sRUBY_ENV_ACTIVATE},
-      JSON.dump({ env: ENV.to_h, ruby_version: RUBY_VERSION, yjit: defined?(RubyVM::YJIT) }))"`;
+
+    // The Ruby activation script is intentionally written as an array that gets joined into a one liner because some
+    // terminals cannot handle line breaks. Do not switch this to a multiline string or that will break activation for
+    // those terminals
+    const script = [
+      "STDERR.printf(%{RUBY_ENV_ACTIVATE%sRUBY_ENV_ACTIVATE}, ",
+      "JSON.dump({ env: ENV.to_h, ruby_version: RUBY_VERSION, yjit: defined?(RubyVM::YJIT) }))",
+    ].join("");
+
+    command += `${ruby} -rjson -e "${script}"`;
 
     if (this.shell) {
       command += "'";


### PR DESCRIPTION
### Motivation

Closes #891, closes https://github.com/Shopify/ruby-lsp/issues/1175

Our Ruby activation script was too long, so we broke it into multiple lines. Based on the information shared in the issue, Windows does not seem to accept line breaks in terminal input and that ends up causing a syntax error.

### Implementation

Instead of using a multiline string interpolation, I just changed to write the script in parts inside an array, which we join at the end.