### PR TITLE
Read server information from initialize result

### DIFF
--- a/src/status.ts
+++ b/src/status.ts
@@ -133,7 +133,9 @@ export class ServerStatus extends StatusItem {
   refresh(): void {
     switch (this.client.state) {
       case ServerState.Running: {
-        this.item.text = `Ruby LSP v${this.client.serverVersion}: Running`;
+        this.item.text = this.client.serverVersion
+          ? `Ruby LSP v${this.client.serverVersion}: Running`
+          : "Ruby LSP: Running";
         this.item.command!.arguments = [STARTED_SERVER_OPTIONS];
         this.item.severity = vscode.LanguageStatusSeverity.Information;
         break;
@@ -359,7 +361,12 @@ export class FormatterStatus extends StatusItem {
   }
 
   refresh(): void {
-    this.item.text = `Using formatter: ${this.client.formatter}`;
+    if (this.client.formatter) {
+      this.item.text = `Formatter: ${this.client.formatter}`;
+    } else {
+      this.item.text =
+        "Formatter: requires server to be v0.12.4 or higher to display this field";
+    }
   }
 
   registerCommand(): void {

--- a/src/test/suite/status.test.ts
+++ b/src/test/suite/status.test.ts
@@ -301,7 +301,7 @@ suite("StatusItems", () => {
     });
 
     test("Status is initialized with the right values", () => {
-      assert.strictEqual(status.item.text, "Using formatter: auto");
+      assert.strictEqual(status.item.text, "Formatter: auto");
       assert.strictEqual(status.item.name, "Formatter");
       assert.strictEqual(status.item.command?.title, "Help");
       assert.strictEqual(status.item.command.command, Command.FormatterHelp);


### PR DESCRIPTION
### Motivation

Running Ruby commands in separate shells to determine server version and formatter is actually an incorrect approach. The [LSP spec](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#initializeResult) allows the server to return its version during the initialize result.

Additionally, although not listed in the specification docs, servers can actually return [any key value pairs](https://github.com/microsoft/vscode-languageserver-node/blob/02806427ce7251ec8fa2ff068febd9a9e59dbd2f/protocol/src/common/protocol.ts#L1501) as part of the initialize result.

Switching to getting this information from the server reduces duplication and removes the need to shell out to Ruby multiple times.

### Implementation

Started reading server version and formatter from the initialize result.