### PR TITLE
Fallback to fetching current workspace using the name

### DIFF
--- a/src/rubyLsp.ts
+++ b/src/rubyLsp.ts
@@ -299,12 +299,18 @@ export class RubyLsp {
   private currentActiveWorkspace(
     activeEditor = vscode.window.activeTextEditor,
   ): Workspace | undefined {
-    if (!activeEditor) {
-      return;
-    }
+    let workspaceFolder: vscode.WorkspaceFolder | undefined;
 
-    const document = activeEditor.document;
-    const workspaceFolder = vscode.workspace.getWorkspaceFolder(document.uri);
+    if (activeEditor) {
+      workspaceFolder = vscode.workspace.getWorkspaceFolder(
+        activeEditor.document.uri,
+      );
+    } else {
+      // If there's no active editor, we search based on the current workspace name
+      workspaceFolder = vscode.workspace.workspaceFolders?.find(
+        (folder) => folder.name === vscode.workspace.name,
+      );
+    }
 
     if (!workspaceFolder) {
       return;


### PR DESCRIPTION
### Motivation

If no file is opened in the editor, then `vscode.window.activeTextEditor` is `undefined`. But even in those scenarios, we can still figure out which workspace is active.

### Implementation

Started using `vscode.workspace.name` as a fallback to figure out the current workspace if no files are opened.