### PR TITLE
Warn users if no lockfile is detected on the configured workspace

### DIFF
--- a/src/rubyLsp.ts
+++ b/src/rubyLsp.ts
@@ -116,9 +116,31 @@ export class RubyLsp {
     // `workspaceContains` activation events in package.json
     if (
       !(await pathExists(path.join(workspaceDir, "Gemfile.lock"))) &&
-      !(await pathExists(path.join(workspaceDir, "gems.locked")))
+      !(await pathExists(path.join(workspaceDir, "gems.locked"))) &&
+      !this.context.globalState.get("rubyLsp.disableMultirootLockfileWarning")
     ) {
-      return;
+      const answer = await vscode.window.showWarningMessage(
+        `Tried to activate the Ruby LSP in ${workspaceDir}, but no lockfile was found. Are you using a monorepo setup?`,
+        "No - launch without bundle",
+        "Yes - see multi-root workspace docs",
+        "Don't show again",
+      );
+
+      if (answer === "Yes - see multi-root workspace docs") {
+        vscode.env.openExternal(
+          vscode.Uri.parse(
+            "https://github.com/Shopify/vscode-ruby-lsp?tab=readme-ov-file#multi-root-workspaces",
+          ),
+        );
+        return;
+      }
+
+      if (answer === "Don't show again") {
+        this.context.globalState.update(
+          "rubyLsp.disableMultirootLockfileWarning",
+          true,
+        );
+      }
     }
 
     const workspace = new Workspace(


### PR DESCRIPTION
### Motivation

Closes #944, closes #942

The change to support multi-root workspaces is causing some confusion for users. Previously, because we always activated the LSP on the first workspace folder entry, the LSP would "work" even in a monorepo without proper multi-root configuration. It would not find the bundle and then just start as if you had none.

Now, with adequate multi-root support, we don't activate if the workspace doesn't include a bundle. We can do better to direct users into applying the proper configurations.

### Implementation

My proposed solution is to show a warning when we try to activate the LSP in a workspace that doesn't contain a bundle, allowing the user to take 3 actions:

- Launch the LSP anyway. This will simply ignore the fact that we didn't find a bundle and the LSP will be launched on its own. This is still useful for scripts
- See the documentation for multi-root workspaces and monorepos, so that they can configure VS Code to identify each directory as a workspace
- Permanently ignore this warning and always launch the LSP