### PR TITLE
Improve debug workspace selection

### DIFF
--- a/src/rubyLsp.ts
+++ b/src/rubyLsp.ts
@@ -31,7 +31,7 @@ export class RubyLsp {
       this.telemetry,
       this.currentActiveWorkspace.bind(this),
     );
-    this.debug = new Debugger(context, this.currentActiveWorkspace.bind(this));
+    this.debug = new Debugger(context, this.getWorkspace.bind(this));
     this.registerCommands(context);
 
     this.statusItems = new StatusItems();

--- a/src/testController.ts
+++ b/src/testController.ts
@@ -197,7 +197,7 @@ export class TestController {
       );
     }
 
-    return vscode.debug.startDebugging(undefined, {
+    return vscode.debug.startDebugging(workspace.workspaceFolder, {
       type: "ruby_lsp",
       name: "Debug",
       request: "launch",
@@ -264,6 +264,7 @@ export class TestController {
     } else {
       this.testController.items.forEach(enqueue);
     }
+    const workspace = this.currentWorkspace();
 
     while (queue.length > 0 && !token.isCancellationRequested) {
       const test = queue.pop()!;
@@ -277,8 +278,6 @@ export class TestController {
       if (test.tags.find((tag) => tag.id === "example")) {
         const start = Date.now();
         try {
-          const workspace = this.currentWorkspace();
-
           if (!workspace) {
             run.errored(test, new vscode.TestMessage("No workspace found"));
             continue;
@@ -334,8 +333,6 @@ export class TestController {
 
     // Make sure to end the run after all tests have been executed
     run.end();
-
-    const workspace = this.currentWorkspace();
 
     if (workspace?.lspClient?.serverVersion) {
       await this.telemetry.sendCodeLensEvent(


### PR DESCRIPTION
### Motivation

There are some edge cases for selecting the active workspace while launching the debugger that we didn't account for before.

For example, if the user has the output tab selected, because VS Code treats that panel as an editor, we receive it as the currently active editor. However, if we try to find a workspace with that URI, we find nothing because the output tab doesn't belong to any workspace.

We should instead rely on the debugger client mechanism better. We receive the current workspace folder as a parameter and we can inject that into the configuration to avoid having to detect the active workspace.

### Implementation

Started relying on the workspace folder informed by VS Code rather than trying to detect the workspace ourselves.

### Manual Tests

Ensure launch configurations and the debug code lens are still working. Then try this:

1. Start the extension on this branch and with the `ruby-lsp` project
2. Select the output tab
3. Try to run the attach launch configuration
4. Verify that you properly get prompted with the list of sockets