### PR TITLE
Clear up `rubyLsp.bundleGemfile` path instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,10 +185,13 @@ the version manager configuration, use the following configuration in VS Code to
 
 ```jsonc
 {
-  "rubyLsp.bundleGemfile": "../../relative/path/to/the/directory/Gemfile",
-  "rubyLsp.bundleGemfile": "/absolute/path/to/the/directory/Gemfile"
+  "rubyLsp.bundleGemfile": "../../path/to/the/directory/Gemfile"
 }
 ```
+
+> [!NOTE]
+>
+> `rubyLsp.bundleGemfile` can be a relative or absolute path.
 
 #### Configuring VS Code debugger
 


### PR DESCRIPTION
The example config as show would result in one config key being overwritten by the other so I thought it would be better to simplify the example to show one instance of the `rubyLsp.bundleGemfile` key and adding a note about relative and absolute path support.

### Motivation

Make the getting started config more clear.

### Implementation

Doc change

### Automated Tests

None, it's the README.

### Manual Tests

Previewed the markdown.
