### PR TITLE
Always activate workspace if a custom Gemfile is configured

### DIFF
--- a/src/rubyLsp.ts
+++ b/src/rubyLsp.ts
@@ -110,11 +110,15 @@ export class RubyLsp {
 
   private async activateWorkspace(workspaceFolder: vscode.WorkspaceFolder) {
     const workspaceDir = workspaceFolder.uri.fsPath;
+    const customBundleGemfile: string = vscode.workspace
+      .getConfiguration("rubyLsp")
+      .get("bundleGemfile")!;
 
     // If one of the workspaces does not contain a lockfile, then we don't try to start a language server. If the user
     // ends up opening a Ruby file inside that workspace, then we lazily activate the workspace. These need to match our
     // `workspaceContains` activation events in package.json
     if (
+      customBundleGemfile.length === 0 &&
       !(await pathExists(path.join(workspaceDir, "Gemfile.lock"))) &&
       !(await pathExists(path.join(workspaceDir, "gems.locked"))) &&
       !this.context.globalState.get("rubyLsp.disableMultirootLockfileWarning")


### PR DESCRIPTION
### Motivation

https://github.com/Shopify/vscode-ruby-lsp/issues/926#issuecomment-1866716381 raised a relevant point. If a custom Gemfile is configured for running the LSP, then we should just start directly, there's no need to check for a lockfile.

### Implementation

Added another check to the conditional.