### PR TITLE
Remove experimental variable guessing in Ruby grammar

### DIFF
--- a/grammars/ruby.cson.json
+++ b/grammars/ruby.cson.json
@@ -2313,11 +2313,6 @@
           "include": "$self"
         }
       ]
-    },
-    {
-      "comment": "This is kindof experimental. There really is no way to perfectly match all regular variables, but you can pretty well assume that any normal word in certain curcumstances that haven't already been scoped as something else are probably variables, and the advantages beat the potential errors",
-      "match": "((?<=\\W)\\b|^)\\w+\\b(?=\\s*([\\]\\)\\}\\=\\+\\-\\*\\/\\^\\$\\,\\.\\&]|<\\s|<<[\\s|\\.])?)",
-      "name": "variable.other.ruby"
     }
   ],
   "repository": {


### PR DESCRIPTION
### Motivation

The grammar file incorrectly assumes most top level method calls are variables.

<img width="601" alt="230160734-f81fc579-5ff1-4760-b0db-3dc5dda01ee7" src="https://github.com/Shopify/vscode-ruby-lsp/assets/161/0d318916-b907-4ec1-a476-b35782a7a40d">

There is a comment in the grammar labeling this as "experimental".

> This is kindof experimental. There really is no way to perfectly match all regular variables, but you can pretty well assume that any normal word in certain curcumstances that haven't already been scoped as something else are probably variables, and the advantages beat the potential errors

I don't agree with "any normal word in certain curcumstances that haven't already been scoped as something else are probably variables" because method calls fall under this. I'd rather we error on the side of not scoping something we don't know.

When the LSP is active it adds semantic highlighting tokens which properly discerns local variables from method calls. It is better to use this instead of the grammar to determine local variables.

See further discussion in #537.

### Implementation

I removed this experimental part of the grammar so it no longer scopes method calls as `variable.other.ruby`.

### Automated Tests

There are no automated tests for the grammar file.

### Manual Tests

You can check this by opening a Ruby file, putting text cursor in a method call, and running the "Inspect Editor Tokens and Scopes" command. It should not show `variable.other.ruby` under `textmate scopes` section.
