### PR TITLE
Add workspace logger

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -14,9 +14,10 @@ import {
   MessageSignature,
 } from "vscode-languageclient/node";
 
-import { LOG_CHANNEL, LSP_NAME, ClientInterface } from "./common";
+import { LSP_NAME, ClientInterface } from "./common";
 import { Telemetry, RequestEvent } from "./telemetry";
 import { Ruby } from "./ruby";
+import { WorkspaceChannel } from "./workspaceChannel";
 
 type EnabledFeatures = Record<string, boolean>;
 
@@ -89,6 +90,7 @@ function getLspExecutables(
 function collectClientOptions(
   configuration: vscode.WorkspaceConfiguration,
   workspaceFolder: vscode.WorkspaceFolder,
+  outputChannel: WorkspaceChannel,
 ): LanguageClientOptions {
   const pullOn: "change" | "save" | "both" =
     configuration.get("pullDiagnosticsOn")!;
@@ -107,7 +109,7 @@ function collectClientOptions(
     ],
     workspaceFolder,
     diagnosticCollectionName: LSP_NAME,
-    outputChannel: LOG_CHANNEL,
+    outputChannel,
     revealOutputChannelOn: RevealOutputChannelOn.Never,
     diagnosticPullOptions,
     initializationOptions: {
@@ -139,6 +141,7 @@ export default class Client extends LanguageClient implements ClientInterface {
     ruby: Ruby,
     createTestItems: (response: CodeLens[]) => void,
     workspaceFolder: vscode.WorkspaceFolder,
+    outputChannel: WorkspaceChannel,
   ) {
     super(
       LSP_NAME,
@@ -146,6 +149,7 @@ export default class Client extends LanguageClient implements ClientInterface {
       collectClientOptions(
         vscode.workspace.getConfiguration("rubyLsp"),
         workspaceFolder,
+        outputChannel,
       ),
     );
 

--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -3,7 +3,8 @@ import fs from "fs/promises";
 
 import * as vscode from "vscode";
 
-import { asyncExec, pathExists, LOG_CHANNEL, RubyInterface } from "./common";
+import { asyncExec, pathExists, RubyInterface } from "./common";
+import { WorkspaceChannel } from "./workspaceChannel";
 
 export enum VersionManager {
   Asdf = "asdf",
@@ -29,13 +30,16 @@ export class Ruby implements RubyInterface {
   private readonly context: vscode.ExtensionContext;
   private readonly customBundleGemfile?: string;
   private readonly cwd: string;
+  private readonly outputChannel: WorkspaceChannel;
 
   constructor(
     context: vscode.ExtensionContext,
     workingFolder: vscode.WorkspaceFolder,
+    outputChannel: WorkspaceChannel,
   ) {
     this.context = context;
     this.workingFolderPath = workingFolder.uri.fsPath;
+    this.outputChannel = outputChannel;
 
     const customBundleGemfile: string = vscode.workspace
       .getConfiguration("rubyLsp")
@@ -78,7 +82,9 @@ export class Ruby implements RubyInterface {
     // If the version manager is auto, discover the actual manager before trying to activate anything
     if (this.versionManager === VersionManager.Auto) {
       await this.discoverVersionManager();
-      LOG_CHANNEL.info(`Discovered version manager ${this.versionManager}`);
+      this.outputChannel.info(
+        `Discovered version manager ${this.versionManager}`,
+      );
     }
 
     try {
@@ -184,7 +190,7 @@ export class Ruby implements RubyInterface {
       command += "'";
     }
 
-    LOG_CHANNEL.info(
+    this.outputChannel.info(
       `Trying to activate Ruby environment with command: ${command} inside directory: ${this.cwd}`,
     );
 
@@ -322,7 +328,7 @@ export class Ruby implements RubyInterface {
         command += "'";
       }
 
-      LOG_CHANNEL.info(
+      this.outputChannel.info(
         `Checking if ${tool} is available on the path with command: ${command}`,
       );
 

--- a/src/test/suite/client.test.ts
+++ b/src/test/suite/client.test.ts
@@ -10,7 +10,8 @@ import { State } from "vscode-languageclient/node";
 import { Ruby, VersionManager } from "../../ruby";
 import { Telemetry, TelemetryApi, TelemetryEvent } from "../../telemetry";
 import Client from "../../client";
-import { asyncExec } from "../../common";
+import { LOG_CHANNEL, asyncExec } from "../../common";
+import { WorkspaceChannel } from "../../workspaceChannel";
 
 class FakeApi implements TelemetryApi {
   public sentEvents: TelemetryEvent[];
@@ -66,8 +67,9 @@ suite("Client", () => {
         update: (_name: string, _value: any) => Promise.resolve(),
       },
     } as unknown as vscode.ExtensionContext;
+    const outputChannel = new WorkspaceChannel("fake", LOG_CHANNEL);
 
-    const ruby = new Ruby(context, workspaceFolder);
+    const ruby = new Ruby(context, workspaceFolder, outputChannel);
     await ruby.activateRuby();
 
     await asyncExec("gem install ruby-lsp", {
@@ -82,6 +84,7 @@ suite("Client", () => {
       ruby,
       () => {},
       workspaceFolder,
+      outputChannel,
     );
 
     try {

--- a/src/test/suite/ruby.test.ts
+++ b/src/test/suite/ruby.test.ts
@@ -6,6 +6,8 @@ import * as os from "os";
 import * as vscode from "vscode";
 
 import { Ruby, VersionManager } from "../../ruby";
+import { WorkspaceChannel } from "../../workspaceChannel";
+import { LOG_CHANNEL } from "../../common";
 
 suite("Ruby environment activation", () => {
   let ruby: Ruby;
@@ -22,10 +24,15 @@ suite("Ruby environment activation", () => {
     const context = {
       extensionMode: vscode.ExtensionMode.Test,
     } as vscode.ExtensionContext;
+    const outputChannel = new WorkspaceChannel("fake", LOG_CHANNEL);
 
-    ruby = new Ruby(context, {
-      uri: { fsPath: tmpPath },
-    } as vscode.WorkspaceFolder);
+    ruby = new Ruby(
+      context,
+      {
+        uri: { fsPath: tmpPath },
+      } as vscode.WorkspaceFolder,
+      outputChannel,
+    );
     await ruby.activateRuby(
       // eslint-disable-next-line no-process-env
       process.env.CI ? VersionManager.None : VersionManager.Chruby,

--- a/src/test/suite/workspaceChannel.test.ts
+++ b/src/test/suite/workspaceChannel.test.ts
@@ -1,0 +1,27 @@
+import * as assert from "assert";
+
+import * as vscode from "vscode";
+
+import { WorkspaceChannel } from "../../workspaceChannel";
+
+class FakeChannel {
+  public readonly messages: string[] = [];
+
+  info(message: string) {
+    this.messages.push(message);
+  }
+}
+
+suite("Workspace channel", () => {
+  test("prepends name as a prefix", () => {
+    const fakeChannel = new FakeChannel();
+    const channel = new WorkspaceChannel(
+      "test",
+      fakeChannel as unknown as vscode.LogOutputChannel,
+    );
+
+    channel.info("hello!");
+    assert.strictEqual(fakeChannel.messages.length, 1);
+    assert.strictEqual(fakeChannel.messages[0], "(test) hello!");
+  });
+});

--- a/src/workspaceChannel.ts
+++ b/src/workspaceChannel.ts
@@ -1,0 +1,75 @@
+import * as vscode from "vscode";
+
+export class WorkspaceChannel implements vscode.LogOutputChannel {
+  public readonly onDidChangeLogLevel: vscode.Event<vscode.LogLevel>;
+  private readonly actualChannel: vscode.LogOutputChannel;
+  private readonly prefix: string;
+
+  constructor(workspaceName: string, actualChannel: vscode.LogOutputChannel) {
+    this.prefix = `(${workspaceName})`;
+    this.actualChannel = actualChannel;
+    this.onDidChangeLogLevel = this.actualChannel.onDidChangeLogLevel;
+  }
+
+  get name(): string {
+    return this.actualChannel.name;
+  }
+
+  get logLevel(): vscode.LogLevel {
+    return this.actualChannel.logLevel;
+  }
+
+  trace(message: string, ...args: any[]): void {
+    this.actualChannel.trace(`${this.prefix} ${message}`, ...args);
+  }
+
+  debug(message: string, ...args: any[]): void {
+    this.actualChannel.debug(`${this.prefix} ${message}`, ...args);
+  }
+
+  info(message: string, ...args: any[]): void {
+    this.actualChannel.info(`${this.prefix} ${message}`, ...args);
+  }
+
+  warn(message: string, ...args: any[]): void {
+    this.actualChannel.warn(`${this.prefix} ${message}`, ...args);
+  }
+
+  error(error: string | Error, ...args: any[]): void {
+    this.actualChannel.error(`${this.prefix} ${error}`, ...args);
+  }
+
+  append(value: string): void {
+    this.actualChannel.append(`${this.prefix} ${value}`);
+  }
+
+  appendLine(value: string): void {
+    this.actualChannel.appendLine(`${this.prefix} ${value}`);
+  }
+
+  replace(value: string): void {
+    this.actualChannel.replace(`${this.prefix} ${value}`);
+  }
+
+  clear(): void {
+    this.actualChannel.clear();
+  }
+
+  show(preserveFocus?: boolean | undefined): void;
+  show(
+    column?: vscode.ViewColumn | undefined,
+    preserveFocus?: boolean | undefined,
+  ): void;
+
+  show(_column?: unknown, preserveFocus?: boolean | undefined): void {
+    this.actualChannel.show(preserveFocus);
+  }
+
+  hide(): void {
+    this.actualChannel.hide();
+  }
+
+  dispose(): void {
+    this.actualChannel.dispose();
+  }
+}


### PR DESCRIPTION
### Motivation

Closes https://github.com/Shopify/ruby-lsp/issues/1298

When we added multi-root workspace support, we discussed that it would be nice to have each language server be tagged with their workspace name in the logs. Back then I investigated it, but the VS Code API doesn't include anything we can use for that out of the box.

When that issue was created, it got me thinking again and I figured we could use the decorator pattern to wrap the actual logger and prefix all operations with the workspace name.

Ideally, VS Code's logger would support tags or something of the sort, but I think this is decent enough while that doesn't happen.

### Implementation

Basically, there's a new `WorkspaceChannel` class that wraps the real logger and stores the workspace name. Then all operations are prefixed with `(WORKSPACE_NAME)`, so that it's easier to tell where things are coming from.

Everything else is delegated to the logger directly.

### Automated Tests

Added a test to verify the prefix is properly inserted.