### PR TITLE
Invoke shell command with separated arguments

### DIFF
--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -168,7 +168,7 @@ export class Ruby implements RubyInterface {
   }
 
   private async activate(ruby: string) {
-    let command = this.shell ? `${this.shell} -ic '` : "";
+    let command = this.shell ? `${this.shell} -i -c '` : "";
 
     // The Ruby activation script is intentionally written as an array that gets joined into a one liner because some
     // terminals cannot handle line breaks. Do not switch this to a multiline string or that will break activation for

--- a/src/ruby.ts
+++ b/src/ruby.ts
@@ -315,7 +315,7 @@ export class Ruby implements RubyInterface {
 
   private async toolExists(tool: string) {
     try {
-      let command = this.shell ? `${this.shell} -ic '` : "";
+      let command = this.shell ? `${this.shell} -i -c '` : "";
       command += `${tool} --version`;
 
       if (this.shell) {


### PR DESCRIPTION
Cf Shopify/vscode-ruby-lsp#978

To support nushell, which doesn't accept having both arguments at the same time. Fish, ZSH, Bash and sh are all compatible with this different syntax

### Manual Tests

⚠️ I haven't tested it locally. However I made sure that all common shells are compatible : Zsh, Fish, Sh and Bash.
