### PR TITLE
We should use join to concatenate paths

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -102,11 +102,10 @@ function collectClientOptions(
 
   const features: EnabledFeatures = configuration.get("enabledFeatures")!;
   const enabledFeatures = Object.keys(features).filter((key) => features[key]);
+  const pattern = `${path.join(workspaceFolder.uri.fsPath, "**", "*")}`;
 
   return {
-    documentSelector: [
-      { language: "ruby", pattern: `${workspaceFolder.uri.fsPath}/**/*` },
-    ],
+    documentSelector: [{ language: "ruby", pattern }],
     workspaceFolder,
     diagnosticCollectionName: LSP_NAME,
     outputChannel,


### PR DESCRIPTION
### Motivation

If someone defined a workspace folder with a trailing slash, we mistakenly concatenating yet another slash after it in our client document selector pattern. This made the LSP start normally, but not receive any requests from VS Code, because no files in the workspace matched the path.

For example
```
# If the workspace folder path was
my_folder/

# Then we would use the pattern
my_folder//**/*

# Which does not match anything
```

### Implementation

The solution is to rely on `path.join`, which always does the right thing and takes operating systems into consideration.