### PR TITLE
Save workspace folder instead of custom workspace object in debug config

### DIFF
--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -104,7 +104,7 @@ export class Debugger
       debugConfiguration.env = workspace.ruby.env;
     }
 
-    debugConfiguration.workspace = workspace;
+    debugConfiguration.targetFolder = workspace.workspaceFolder;
 
     const workspacePath = workspace.workspaceFolder.uri.fsPath;
 
@@ -166,8 +166,7 @@ export class Debugger
     let initialized = false;
 
     const configuration = session.configuration;
-    const workspaceFolder: vscode.WorkspaceFolder =
-      configuration.workspace.workspaceFolder;
+    const workspaceFolder: vscode.WorkspaceFolder = configuration.targetFolder;
     const cwd = workspaceFolder.uri.fsPath;
     const sockPath = this.socketPath(workspaceFolder.name);
 


### PR DESCRIPTION
### Motivation

Closes #987 

In #976, we started saving our custom `Workspace` objects into the debugging session configuration.

I remember testing this and it working, but I might be misremembering. It indeed causes the strange issue reported in #987, which just opens the `launch.json` file instead of launching the debugger.

I tried step debugging and it leads inside VS Code internals in some serialization code. My assumption is that it serializes the configuration and something fails because our custom object must not conform to whatever interface is needed to serialize/deserialize. 

### Implementation

We only need the workspace folder, so let's save only that in the configuration.

### Manual Tests

1. Start the LSP on this branch
2. Launch any debugging task from the debug and run panel
3. It should launch the task and not open the `launch.json` file