### PR TITLE
Add debugger launch test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.2"
+          ruby-version: "3.3"
 
       - name: 📦 Install dependencies
         run: yarn --frozen-lockfile

--- a/src/test/suite/client.test.ts
+++ b/src/test/suite/client.test.ts
@@ -57,7 +57,7 @@ suite("Client", () => {
       name: path.basename(tmpPath),
       index: 0,
     };
-    fs.writeFileSync(path.join(tmpPath, ".ruby-version"), "3.2.2");
+    fs.writeFileSync(path.join(tmpPath, ".ruby-version"), "3.3.0");
 
     const context = {
       extensionMode: vscode.ExtensionMode.Test,

--- a/src/test/suite/debugger.test.ts
+++ b/src/test/suite/debugger.test.ts
@@ -6,8 +6,10 @@ import * as os from "os";
 import * as vscode from "vscode";
 
 import { Debugger } from "../../debugger";
-import { Ruby } from "../../ruby";
+import { Ruby, VersionManager } from "../../ruby";
 import { Workspace } from "../../workspace";
+import { WorkspaceChannel } from "../../workspaceChannel";
+import { LOG_CHANNEL, asyncExec } from "../../common";
 
 suite("Debugger", () => {
   test("Provide debug configurations returns the default configs", () => {
@@ -134,4 +136,85 @@ suite("Debugger", () => {
     context.subscriptions.forEach((subscription) => subscription.dispose());
     fs.rmSync(tmpPath, { recursive: true, force: true });
   });
+
+  test("Launching the debugger", async () => {
+    // eslint-disable-next-line no-process-env
+    if (process.env.CI) {
+      await vscode.workspace
+        .getConfiguration("rubyLsp")
+        .update("rubyVersionManager", VersionManager.None, true, true);
+    }
+
+    // By default, VS Code always saves all open files when launching a debugging session. This is a problem for tests
+    // because it attempts to save an untitled test file and then we get stuck in the save file dialog with no way of
+    // closing it. We have to disable that before running this test
+    const currentSaveBeforeStart = await vscode.workspace
+      .getConfiguration("debug")
+      .get("saveBeforeStart");
+    await vscode.workspace
+      .getConfiguration("debug")
+      .update("saveBeforeStart", "none", true, true);
+
+    const tmpPath = fs.mkdtempSync(
+      path.join(os.tmpdir(), "ruby-lsp-test-debugger"),
+    );
+    fs.writeFileSync(path.join(tmpPath, "test.rb"), "1 + 1");
+    fs.writeFileSync(path.join(tmpPath, ".ruby-version"), "3.3.0");
+    fs.writeFileSync(
+      path.join(tmpPath, "Gemfile"),
+      'source "https://rubygems.org"\ngem "debug"',
+    );
+
+    const context = { subscriptions: [] } as unknown as vscode.ExtensionContext;
+    const outputChannel = new WorkspaceChannel("fake", LOG_CHANNEL);
+    const workspaceFolder: vscode.WorkspaceFolder = {
+      uri: vscode.Uri.from({ scheme: "file", path: tmpPath }),
+      name: path.basename(tmpPath),
+      index: 0,
+    };
+    const ruby = new Ruby(context, workspaceFolder, outputChannel);
+    await ruby.activateRuby();
+
+    try {
+      await asyncExec("gem install debug", { env: ruby.env, cwd: tmpPath });
+      await asyncExec("bundle install", { env: ruby.env, cwd: tmpPath });
+    } catch (error: any) {
+      assert.fail(`Failed to bundle install: ${error.message}`);
+    }
+
+    assert.ok(fs.existsSync(path.join(tmpPath, "Gemfile.lock")));
+    assert.match(
+      fs.readFileSync(path.join(tmpPath, "Gemfile.lock")).toString(),
+      /debug/,
+    );
+
+    const debug = new Debugger(context, () => {
+      return {
+        ruby,
+        workspaceFolder,
+      } as Workspace;
+    });
+
+    try {
+      await vscode.debug.startDebugging(workspaceFolder, {
+        type: "ruby_lsp",
+        name: "Debug",
+        request: "launch",
+        program: `ruby ${path.join(tmpPath, "test.rb")}`,
+      });
+    } catch (error: any) {
+      assert.fail(`Failed to launch debugger: ${error.message}`);
+    }
+
+    // The debugger might take a bit of time to disconnect from the editor. We need to perform cleanup when we receive
+    // the termination callback or else we try to dispose of the debugger client too early
+    vscode.debug.onDidTerminateDebugSession(async (_session) => {
+      debug.dispose();
+      context.subscriptions.forEach((subscription) => subscription.dispose());
+      fs.rmSync(tmpPath, { recursive: true, force: true });
+      await vscode.workspace
+        .getConfiguration("debug")
+        .update("saveBeforeStart", currentSaveBeforeStart, true, true);
+    });
+  }).timeout(45000);
 });

--- a/src/test/suite/ruby.test.ts
+++ b/src/test/suite/ruby.test.ts
@@ -19,7 +19,7 @@ suite("Ruby environment activation", () => {
     }
 
     const tmpPath = fs.mkdtempSync(path.join(os.tmpdir(), "ruby-lsp-test-"));
-    fs.writeFileSync(path.join(tmpPath, ".ruby-version"), "3.2.2");
+    fs.writeFileSync(path.join(tmpPath, ".ruby-version"), "3.3.0");
 
     const context = {
       extensionMode: vscode.ExtensionMode.Test,


### PR DESCRIPTION
### Motivation

We had a few debugger related issues recently, so we need to continue on our quest to improve our test coverage of the extension. This PR adds a launch test for the debugger that actually spawns it, so that we can catch more issues on CI.

### Implementation

The test performs all of the necessary setup, like creating a Gemfile and activating Ruby. The it attempts to launch the debugger with a simple `1 + 1` Ruby program, waits for the debugger to finish and performs clean up.

I also bumped our Ruby version to 3.3.0.