### PR TITLE
Use simple object for debugConfiguration.targetFolder

### DIFF
--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -104,9 +104,12 @@ export class Debugger
       debugConfiguration.env = workspace.ruby.env;
     }
 
-    debugConfiguration.targetFolder = workspace.workspaceFolder;
-
     const workspacePath = workspace.workspaceFolder.uri.fsPath;
+
+    debugConfiguration.targetFolder = {
+      path: workspacePath,
+      name: workspace.workspaceFolder.name,
+    };
 
     let customGemfilePath = path.join(workspacePath, ".ruby-lsp", "Gemfile");
     if (fs.existsSync(customGemfilePath)) {
@@ -166,8 +169,8 @@ export class Debugger
     let initialized = false;
 
     const configuration = session.configuration;
-    const workspaceFolder: vscode.WorkspaceFolder = configuration.targetFolder;
-    const cwd = workspaceFolder.uri.fsPath;
+    const workspaceFolder = configuration.targetFolder;
+    const cwd = workspaceFolder.path;
     const sockPath = this.socketPath(workspaceFolder.name);
 
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
### Motivation

Because `debugConfiguration` can be serialized/deserialized, `debugConfiguration.targetFolder.uri` may be converted into a plain JS object and loses the `fsPath` property and causes `cwd` to be undefined when working with a remote workspace.

### Implementation

This commit fixes the issue by storing the `fsPath` property directly in `debugConfiguration.targetFolder`.

### Automated Tests

<!-- We hope you added unit tests as part of your changes, just state that you have. If you haven't, state why. -->

### Manual Tests

It's been manually tested on Spin.
