### PR TITLE
fix: include prerelease in changelog only for prerelease

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -33,7 +33,10 @@ jobs:
               repo: context.repo.repo,
             });
 
+            const includePrereleases = context.payload.release.prerelease;
+
             const changelog = releases
+              .filter((release) => includePrereleases || !release.prerelease)
               .map((release) => `# ${release.tag_name}\n${release.body}\n`)
               .join("\n");
 


### PR DESCRIPTION
### Motivation

Closes #996

Prerelease are included in changelog, which render something not ordered and hard to read for user.
 
### Implementation

Filter out [prerelease](https://docs.github.com/en/rest/releases/releases?apiVersion=2022-11-28#list-releases).

### Automated Tests

N/A

### Manual Tests

Same as #810, impossible to test this flow exactly to me, but I added this step in the CI workflow, you can see the result [on my fork](https://github.com/snutij/vscode-ruby-lsp/actions/runs/7655678802/job/20862304406), toggle the `Cat` part. No prerelease are included. 