### PR TITLE
Convert test output newlines to \r\n

### DIFF
--- a/src/testController.ts
+++ b/src/testController.ts
@@ -289,7 +289,7 @@ export class TestController {
             workspace.ruby.env,
           );
 
-          run.appendOutput(output, undefined, test);
+          run.appendOutput(output.replace(/\r?\n/g, "\r\n"), undefined, test);
           run.passed(test, Date.now() - start);
         } catch (err: any) {
           const duration = Date.now() - start;


### PR DESCRIPTION
### Motivation

As is documented in the [testing api documentation](https://code.visualstudio.com/api/extension-guides/testing#test-output) VSCode expects test output to have `\r\n` newlines, which is not the default value for many tools and it is up to the extension to convert them. 

### Implementation

N/A

### Automated Tests

Not implemented, `TestController` currently lacks unit tests.

### Manual Tests

Run a ruby unit test with multiline output, compare output with a run executed in the terminal.