### PR TITLE
Do not redirect to `OUTPUT` channel when debugger close on error

### DIFF
--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -280,7 +280,6 @@ export class Debugger
         if (code) {
           const message = `Debugger exited with status ${code}. Check the output channel for more information.`;
           this.console.append(message);
-          LOG_CHANNEL.show();
           reject(new Error(message));
         }
       });


### PR DESCRIPTION
### Motivation

Closes: https://github.com/Shopify/vscode-ruby-lsp/issues/951

- Remove the redirection to `OUTPUT` channel while debugger close on error due to file code. This redirection do not make sense as user want to see the error.
- Resolves the issue that `DEBUG CONSOLE` was cleaned.

### Implementation

Just remove the `LOG_CHANNEL.show();` part while debug session close on error.

### Automated Tests

Not added, feel free to ask if this is required.

### Manual Tests


https://github.com/Shopify/vscode-ruby-lsp/assets/38727166/65802467-45bc-4c6e-9871-d952c19fa885

