### PR TITLE
Add code lens for running migrations

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,12 @@
         "when": "editorActive && editorLangId == ruby"
       },
       {
+        "command": "rubyLsp.runMigrationInTerminal",
+        "title": "Run current migration in terminal",
+        "category": "Ruby LSP",
+        "when": "editorActive && editorLangId == ruby"
+      },
+      {
         "command": "rubyLsp.showSyntaxTree",
         "title": "Show syntax tree",
         "category": "Ruby LSP"

--- a/src/common.ts
+++ b/src/common.ts
@@ -19,6 +19,7 @@ export enum Command {
   RunTest = "rubyLsp.runTest",
   RunTestInTerminal = "rubyLsp.runTestInTerminal",
   DebugTest = "rubyLsp.debugTest",
+  RunMigrationInTerminal = "rubyLsp.runMigrationInTerminal",
   OpenLink = "rubyLsp.openLink",
   ShowSyntaxTree = "rubyLsp.showSyntaxTree",
 }

--- a/src/migrationController.ts
+++ b/src/migrationController.ts
@@ -1,0 +1,64 @@
+import * as vscode from "vscode";
+
+import { Telemetry } from "./telemetry";
+import { Workspace } from "./workspace";
+
+export class MigrationController {
+  private terminal: vscode.Terminal | undefined;
+  private readonly telemetry: Telemetry;
+  private readonly currentWorkspace: () => Workspace | undefined;
+
+  constructor(
+    _context: vscode.ExtensionContext,
+    telemetry: Telemetry,
+    currentWorkspace: () => Workspace | undefined,
+  ) {
+    this.telemetry = telemetry;
+    this.currentWorkspace = currentWorkspace;
+
+    vscode.window.onDidCloseTerminal((terminal: vscode.Terminal): void => {
+      if (terminal === this.terminal) this.terminal = undefined;
+    });
+  }
+
+  async runMigrationInTerminal(command?: string) {
+    // eslint-disable-next-line no-param-reassign
+    command ??= "bin/rails db:migrate";
+
+    if (this.terminal === undefined) {
+      this.terminal = this.getTerminal();
+    }
+
+    this.terminal.show();
+    this.terminal.sendText(command);
+
+    const workspace = this.currentWorkspace();
+
+    if (workspace?.lspClient?.serverVersion) {
+      await this.telemetry.sendCodeLensEvent(
+        "migrate_in_terminal",
+        workspace.lspClient.serverVersion,
+      );
+    }
+  }
+
+  // Get an existing terminal or create a new one. For multiple workspaces, it's important to create a new terminal for
+  // each workspace because they might be using different Ruby versions. If there's no workspace, we fallback to a
+  // generic name
+  private getTerminal() {
+    const workspace = this.currentWorkspace();
+    const name = workspace
+      ? `${workspace.workspaceFolder.name}: migration`
+      : "Ruby LSP: migration";
+
+    const previousTerminal = vscode.window.terminals.find(
+      (terminal) => terminal.name === name,
+    );
+
+    return previousTerminal
+      ? previousTerminal
+      : vscode.window.createTerminal({
+          name,
+        });
+  }
+}

--- a/src/rubyLsp.ts
+++ b/src/rubyLsp.ts
@@ -10,6 +10,7 @@ import { Command, STATUS_EMITTER, pathExists } from "./common";
 import { VersionManager } from "./ruby";
 import { StatusItems } from "./status";
 import { TestController } from "./testController";
+import { MigrationController } from "./migrationController";
 import { Debugger } from "./debugger";
 
 // The RubyLsp class represents an instance of the entire extension. This should only be instantiated once at the
@@ -21,12 +22,18 @@ export class RubyLsp {
   private readonly context: vscode.ExtensionContext;
   private readonly statusItems: StatusItems;
   private readonly testController: TestController;
+  private readonly migrationController: MigrationController;
   private readonly debug: Debugger;
 
   constructor(context: vscode.ExtensionContext) {
     this.context = context;
     this.telemetry = new Telemetry(context);
     this.testController = new TestController(
+      context,
+      this.telemetry,
+      this.currentActiveWorkspace.bind(this),
+    );
+    this.migrationController = new MigrationController(
       context,
       this.telemetry,
       this.currentActiveWorkspace.bind(this),
@@ -327,6 +334,12 @@ export class RubyLsp {
       vscode.commands.registerCommand(
         Command.DebugTest,
         this.testController.debugTest.bind(this.testController),
+      ),
+      vscode.commands.registerCommand(
+        Command.RunMigrationInTerminal,
+        this.migrationController.runMigrationInTerminal.bind(
+          this.migrationController,
+        ),
       ),
     );
   }

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -20,7 +20,7 @@ export interface ConfigurationEvent {
 }
 
 export interface CodeLensEvent {
-  type: "test" | "debug" | "test_in_terminal" | "link";
+  type: "test" | "debug" | "test_in_terminal" | "migrate_in_terminal" | "link";
   lspVersion: string;
 }
 


### PR DESCRIPTION
### Motivation

Adds code lens to run migrations to specific versions in the terminal. This is convenient because it allows developers to quickly rollback or fast-forward to specific schema versions with a click.

Part of https://github.com/Shopify/ruby-lsp-rails/pull/239

### Implementation

Followed the example of the test running controller and test command registration.

### Automated Tests

I don't see any tests for the test command, do they exist? Happy to add tests if I have an example to follow.

### Manual Tests

Build the extension, install the extension on a Rails app with Ruby LSP + Rails extension setup using https://github.com/Shopify/ruby-lsp-rails/pull/239. Then, navigate to a migration to observe the added code lens.
