### PR TITLE
Remove open remote code lens related code

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ language status center right next to the language mode Ruby and select `Manage` 
 
 ![Ruby LSP status center](extras/ruby_lsp_status_center.png)
 
-It's also possible to configure with more granularity code lens and inlay hint features, see the [Ruby LSP server
+It's also possible to configure with more granularity inlay hint features, see the [Ruby LSP server
 documentation](https://shopify.github.io/ruby-lsp/RubyLsp/Requests.html).
 
 #### Ruby version managers

--- a/package.json
+++ b/package.json
@@ -167,7 +167,7 @@
               "default": true
             },
             "codeLens": {
-              "description": "Enable code lens, which generates clickable text to enrich editor experience (run tests, open Gem pages, ...)",
+              "description": "Enable code lens, which generates clickable text to enrich editor experience",
               "type": "boolean",
               "default": true
             },
@@ -211,19 +211,6 @@
           "description": "Turn on/off specific features from request",
           "type": "object",
           "properties": {
-            "codeLens": {
-              "description": "Customize code lens features",
-              "type": "object",
-              "properties": {
-                "enableAll": {
-                  "type": "boolean"
-                },
-                "gemfileLinks": {
-                  "description": "Enable codelens in the Gemfile to open the gem repository",
-                  "type": "boolean"
-                }
-              }
-            },
             "inlayHint": {
               "description": "Customize inlay hint features",
               "type": "object",

--- a/src/common.ts
+++ b/src/common.ts
@@ -19,7 +19,6 @@ export enum Command {
   RunTest = "rubyLsp.runTest",
   RunTestInTerminal = "rubyLsp.runTestInTerminal",
   DebugTest = "rubyLsp.debugTest",
-  OpenLink = "rubyLsp.openLink",
   ShowSyntaxTree = "rubyLsp.showSyntaxTree",
 }
 

--- a/src/rubyLsp.ts
+++ b/src/rubyLsp.ts
@@ -191,21 +191,6 @@ export class RubyLsp {
         await workspace?.stop();
       }),
       vscode.commands.registerCommand(
-        Command.OpenLink,
-        async (link: string) => {
-          vscode.env.openExternal(vscode.Uri.parse(link));
-
-          const workspace = this.currentActiveWorkspace();
-
-          if (workspace?.lspClient?.serverVersion) {
-            await this.telemetry.sendCodeLensEvent(
-              "link",
-              workspace.lspClient.serverVersion,
-            );
-          }
-        },
-      ),
-      vscode.commands.registerCommand(
         Command.ShowSyntaxTree,
         this.showSyntaxTree.bind(this),
       ),

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -20,7 +20,7 @@ export interface ConfigurationEvent {
 }
 
 export interface CodeLensEvent {
-  type: "test" | "debug" | "test_in_terminal" | "link";
+  type: "test" | "debug" | "test_in_terminal";
   lspVersion: string;
 }
 


### PR DESCRIPTION
### Motivation

Related to: https://github.com/Shopify/ruby-lsp/pull/1344

We are moving open remote link to the hover (instead of lens now), so code related to this lens will be unused. 

### Implementation

Two main kinds of code:
- code lens purely 
- configuration of code lens feature

### Automated Tests

Not added, feel free to tell me if I can increase coverage somewhere. 👍 

### Manual Tests

See the related PR to check rendering in Gemfile. Other lenses for tests are still working.