### PR TITLE
Improve GraphQL regex to match 'GQL'

### DIFF
--- a/grammars/ruby.cson.json
+++ b/grammars/ruby.cson.json
@@ -1671,13 +1671,13 @@
       ]
     },
     {
-      "begin": "(?=(?><<[-~]([\"'`]?)((?:[_\\w]+_|)GRAPHQL)\\b\\1))",
+      "begin": "(?=(?><<[-~]([\"'`]?)((?:[_\\w]+_|)(?:GRAPHQL|GQL))\\b\\1))",
       "comment": "Heredoc with embedded GraphQL",
       "end": "(?!\\G)",
       "name": "meta.embedded.block.graphql",
       "patterns": [
         {
-          "begin": "(?><<[-~]([\"'`]?)((?:[_\\w]+_|)GRAPHQL)\\b\\1)",
+          "begin": "(?><<[-~]([\"'`]?)((?:[_\\w]+_|)(?:GRAPHQL|GQL))\\b\\1)",
           "beginCaptures": {
             "0": {
               "name": "punctuation.definition.string.begin.ruby"

--- a/src/test/suite/grammars.test.ts
+++ b/src/test/suite/grammars.test.ts
@@ -27,7 +27,6 @@ const EMBEDDED_HEREDOC_LANGUAGES: InferrableLanguageConfigOrLabel[] = [
   // Languages for which we can infer everything from the comment label
   "C",
   "CSS",
-  "GraphQL",
   "Lua",
   "Ruby",
   "SQL",
@@ -36,6 +35,10 @@ const EMBEDDED_HEREDOC_LANGUAGES: InferrableLanguageConfigOrLabel[] = [
   {
     id: "cpp",
     label: "C++",
+  },
+  {
+    label: "GraphQL",
+    delimiters: ["GRAPHQL", "GQL"],
   },
   {
     label: "HAML",


### PR DESCRIPTION
### Motivation

#### Background
<details>
Using a heredoc to syntax highlight GraphQL snippets currently breaks the rest of the file's highlighting:

<img width="242" alt="image" src="https://github.com/Shopify/vscode-ruby-lsp/assets/11562621/e919dbc9-8b86-41b4-958c-ef155e353e4c">


I investigated it briefly and apparently, there is a conflict between the [GraphQL Syntax highlighting](https://marketplace.visualstudio.com/items?itemName=GraphQL.vscode-graphql-syntax) extension and Ruby LSP. Two evidences that this is the case:

1. When we inspect the tokens, we see that the token that is being displayed is the one in the [GraphQL extension grammar](https://github.com/graphql/graphiql/blob/main/packages/vscode-graphql-syntax/grammars/graphql.rb.json).

![image](https://github.com/Shopify/vscode-ruby-lsp/assets/11562621/ab9b3d23-1a54-4b72-a272-2b7475595e92)

2. Ruby LSP grammar for GraphQL has an additional match for the backtick symbol (`) that is not present in the GraphQL Syntax extension. If we try to use it, the highlighting works as expected:

![image](https://github.com/Shopify/vscode-ruby-lsp/assets/11562621/402ba1b4-bb5f-4632-a6f8-34a3991bc3c0)

I'm not how to make Ruby LSP grammar take precedence over the GraphQL extension grammar (maybe using [injectionSelector](https://code.visualstudio.com/api/language-extensions/syntax-highlight-guide#injection-grammars)).
</details>

#### Alternative
As I've seen in other codebases, there is also the common usage of `GQL` to delimit the GraphQL syntax highlight block. Since the Ruby LSP regex nor the GraphQL Syntax highlight regex matches it, if we add it here we gain precedence and are able to correctly highlight our whole file:

![image](https://github.com/Shopify/vscode-ruby-lsp/assets/11562621/4b93e4f0-a72c-46ef-9f8c-aa6b92307f45)


### Implementation

Added the keyword `GQL` to be matched by the GraphQL grammar block `begin` regex, the same syntax that is used to match both `JS|JAVASCRIPT`.

### Automated Tests

Updated how we test for GraphQL, moving it to an object that contains both delimiters `["GQL", "GRAPHQL"]`

### Manual Tests

Writing a GraphQL snippet that starts and ends with `GQL` should highlight only the block between them and keep the rest of the file syntax highlight working.
