### PR TITLE
Always print errors to the output tab

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -131,6 +131,7 @@ export default class Client extends LanguageClient implements ClientInterface {
   private readonly baseFolder;
   private requestId = 0;
 
+  #outputChannel: WorkspaceChannel;
   #context: vscode.ExtensionContext;
   #formatter: string;
 
@@ -162,6 +163,7 @@ export default class Client extends LanguageClient implements ClientInterface {
     this.createTestItems = createTestItems;
     this.#context = context;
     this.ruby = ruby;
+    this.#outputChannel = outputChannel;
     this.#formatter = "";
   }
 
@@ -254,6 +256,11 @@ export default class Client extends LanguageClient implements ClientInterface {
       telemetryData.errorMessage = error.data.errorMessage;
       telemetryData.backtrace = error.data.backtrace;
       errorResult = error;
+
+      // Also display errors in the output channel. The intention is to make it easier for users to report issues
+      this.#outputChannel.error(
+        `Server error: ${telemetryData.errorClass} - ${telemetryData.errorMessage}\n\n${telemetryData.backtrace}`,
+      );
     }
     Perf.mark(`${benchmarkId}.end`);
 


### PR DESCRIPTION
### Motivation

If an error occurs in the server, it's difficult for users to report it. We should always print the error information to the output tab so that they can easily attach that to their bug reports.

### Implementation

Started logging the error information whenever one occurs.