### PR TITLE
Display a warning if formatOnSaveMode is modifications

### DIFF
--- a/src/rubyLsp.ts
+++ b/src/rubyLsp.ts
@@ -173,6 +173,7 @@ export class RubyLsp {
     // If we successfully activated a workspace, then we can start showing the dependencies tree view. This is necessary
     // so that we can avoid showing it on non Ruby projects
     vscode.commands.executeCommand("setContext", "rubyLsp.activated", true);
+    this.showFormatOnSaveModeWarning(workspace);
   }
 
   // Registers all extension commands. Commands can only be registered once, so this happens in the constructor. For
@@ -467,6 +468,32 @@ export class RubyLsp {
           preserveFocus: true,
         });
       }
+    }
+  }
+
+  private async showFormatOnSaveModeWarning(workspace: Workspace) {
+    const setting = vscode.workspace.getConfiguration("editor", {
+      languageId: "ruby",
+    });
+    const value: string = setting.get("formatOnSaveMode")!;
+
+    if (value === "file") {
+      return;
+    }
+
+    const answer = await vscode.window.showWarningMessage(
+      `The "editor.formatOnSaveMode" setting is set to ${value} in workspace ${workspace.workspaceFolder.name}, which
+      is currently unsupported by the Ruby LSP. If you'd like to have formatting enabled, please set it to 'file'`,
+      "Change setting to 'file'",
+      "Use without formatting",
+    );
+
+    if (answer === "Change setting to 'file'") {
+      await setting.update(
+        "formatOnSaveMode",
+        "file",
+        vscode.ConfigurationTarget.Global,
+      );
     }
   }
 }


### PR DESCRIPTION
### Motivation

If users configure VS Code with `"editor.formatOnSaveMode": "modifications"`, the editor stops sending `textDocument/formatting` requests and starts sending `textDocument/rangeFormatting` requests to the LSP.

The idea is that VS Code grabs the modifications from git and asks to format only that portion of the file.

There are two issues with this:
1. We don't currently support range formatting
2. Even if we supported it, the only tool that currently has support for formatting files partially is Syntax Tree. RuboCop always considers any code you give it to be a complete file

In the current experience, users with this setting simply don't get formatting (because the requests are never sent), but still get all of the rest. This is confusing and we can do better.

### Implementation

Started checking for the setting and showing a warning. We offer the option to fix the user's configuration or do nothing.

**Question**: should we remember that they selected `Use without formatting` and never prompt again? Or are we okay with prompting every time the LSP is launched?

### Manual Tests

1. Change your settings to have `"editor.formatOnSaveMode": "modifications"`
2. Start the extension in development mode on this branch
3. Verify you get a warning
4. Click the Change setting button
5. Verify the setting is updated and formatting works