### PR TITLE
Add debounce to restart watchers

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -69,3 +69,29 @@ export async function pathExists(
     return false;
   }
 }
+
+// Creates a debounced version of a function with the specified delay. If the function is invoked before the delay runs
+// out, then the previous invocation of the function gets cancelled and a new one is scheduled.
+//
+// Example:
+// ```typescript
+// // Invoking debouncedFoo will only execute after a second has passed since the last of all invocations
+// const debouncedFoo = debounce(this.foo.bind(this), 1000);
+// ```
+export function debounce(fn: (...args: any[]) => Promise<void>, delay: number) {
+  let timeoutID: NodeJS.Timeout | null = null;
+
+  return function (...args: any[]) {
+    if (timeoutID) {
+      clearTimeout(timeoutID);
+    }
+
+    return new Promise((resolve, reject) => {
+      timeoutID = setTimeout(() => {
+        fn(...args)
+          .then((result) => resolve(result))
+          .catch((error) => reject(error));
+      }, delay);
+    });
+  };
+}


### PR DESCRIPTION
### Motivation

One thing that causes frustration is that when pulling and switching branches, we sometimes reboot the server too quickly and it results in errors or multiple unnecessary restarts.

There is also a race condition between the rebase and the lockfile watchers. If you rebase a branch and get an updated lockfile and a rebase conflict at the same exact time, there's no way to tell if which watcher will fire first. We could end up in a situation where we trigger the lockfile reboot and only after set the rebase flag to prevent further restarts, which is too late.

I think adding a debounce to our restart watchers will result in a smoother experience.

### Implementation

1. Created a debounce function. It receives another function and a delay as arguments, which then creates a version of that function that is debounced by the specified delay. The final function is only invoked if the timer runs out and all other invocations that occur before then are cancelled automatically
2. Used the debounce function in our lockfile restarts

### Manual Tests

1. Start the LSP on this branch
2. Make a change to the lockfile of a project
3. Verify that the LSP doesn't restart immediately, but rather waits a couple of seconds and then restarts properly